### PR TITLE
Add sdb2json command for JSON output

### DIFF
--- a/sdbtool/cli/__init__.py
+++ b/sdbtool/cli/__init__.py
@@ -6,6 +6,7 @@ COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
 """
 
 from sdbtool.cli.sdb2xml import command as sdb2xml_command
+from sdbtool.cli.sdb2json import command as sdb2json_command
 from sdbtool.cli.attributes import command as attributes_command
 from sdbtool.cli.info import command as info_command
 from sdbtool.cli.gui import command as gui_command
@@ -29,6 +30,7 @@ def sdbtool_command():
 
 
 sdbtool_command.add_command(sdb2xml_command)
+sdbtool_command.add_command(sdb2json_command)
 sdbtool_command.add_command(attributes_command)
 sdbtool_command.add_command(info_command)
 sdbtool_command.add_command(gui_command)

--- a/sdbtool/cli/common.py
+++ b/sdbtool/cli/common.py
@@ -1,0 +1,40 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     Shared CLI options and utilities for sdbtool commands
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+import click
+
+AUTO_EXCLUDE = ["INDEXES", "STRINGTABLE"]
+
+
+def expand_exclude(exclude: str) -> list[str]:
+    """Parse and expand the --exclude option value, resolving the 'auto' alias."""
+    tags = [c.strip() for c in exclude.split(",") if c.strip()]
+    if "auto" in tags:
+        tags.remove("auto")
+        tags.extend(AUTO_EXCLUDE)
+    return tags
+
+
+def common_sdb_options(f):
+    """Shared --exclude, --tagid, and --tag options for SDB conversion commands."""
+    f = click.option(
+        "--exclude",
+        type=click.STRING,
+        default="",
+        metavar="TAG,TAG",
+        help="Exclude specified tags from the SDB file."
+        " Use 'auto' as an alias for 'INDEXES,STRINGTABLE'.",
+    )(f)
+    f = click.option(
+        "--tagid/--no-tagid",
+        default=False,
+        help="Include tagids (index in the database) in the output.",
+    )(f)
+    f = click.option(
+        "--tag/--no-tag", default=False, help="Include tag number in the output."
+    )(f)
+    return f

--- a/sdbtool/cli/sdb2json.py
+++ b/sdbtool/cli/sdb2json.py
@@ -2,11 +2,12 @@
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
 PURPOSE:     cli handling for the sdb2json command
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 import click
 from sdbtool.cli.types import SDB_DATABASE
+from sdbtool.cli.common import common_sdb_options, expand_exclude
 from sdbtool.sdb2json import convert as sdb2json_convert
 
 
@@ -19,38 +20,19 @@ from sdbtool.sdb2json import convert as sdb2json_convert
     help="Path to the output JSON file, or '-' for stdout.",
 )
 @click.option(
-    "--exclude",
-    type=click.STRING,
-    default="",
-    metavar="TAG,TAG",
-    help="Exclude specified tags from the SDB file."
-    " Use 'auto' as an alias for 'INDEXES,STRINGTABLE'.",
-)
-@click.option(
     "--annotations/--no-annotations",
     default=True,
     help="Include annotations (e.g. decoded flag names, UUIDs) as 'comment' fields [default: enabled].",
 )
-@click.option(
-    "--tagid/--no-tagid",
-    default=False,
-    help="Include tagids (index in the database) in the JSON output.",
-)
-@click.option(
-    "--tag/--no-tag", default=False, help="Include tag number in the JSON output."
-)
+@common_sdb_options
 @click.pass_context
-def command(ctx, input_file, output, exclude, annotations, tagid, tag):
+def command(ctx, input_file, output, annotations, exclude, tagid, tag):
     """Convert an SDB file to JSON format."""
     try:
-        exclude = [c.strip() for c in exclude.split(",") if c.strip()]
-        if "auto" in exclude:
-            exclude.remove("auto")
-            exclude.extend(["INDEXES", "STRINGTABLE"])
         sdb2json_convert(
             db=input_file,
             output_stream=output,
-            exclude_tags=exclude,
+            exclude_tags=expand_exclude(exclude),
             with_annotations=annotations,
             with_tagid=tagid,
             with_tag=tag,

--- a/sdbtool/cli/sdb2json.py
+++ b/sdbtool/cli/sdb2json.py
@@ -1,0 +1,60 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     cli handling for the sdb2json command
+COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+import click
+from sdbtool.cli.types import SDB_DATABASE
+from sdbtool.sdb2json import convert as sdb2json_convert
+
+
+@click.command("sdb2json")
+@click.argument("input_file", type=SDB_DATABASE, required=True)
+@click.option(
+    "--output",
+    type=click.File("w", encoding="utf-8"),
+    default="-",
+    help="Path to the output JSON file, or '-' for stdout.",
+)
+@click.option(
+    "--exclude",
+    type=click.STRING,
+    default="",
+    metavar="TAG,TAG",
+    help="Exclude specified tags from the SDB file."
+    " Use 'auto' as an alias for 'INDEXES,STRINGTABLE'.",
+)
+@click.option(
+    "--annotations/--no-annotations",
+    default=True,
+    help="Include annotations (e.g. decoded flag names, UUIDs) as 'comment' fields [default: enabled].",
+)
+@click.option(
+    "--tagid/--no-tagid",
+    default=False,
+    help="Include tagids (index in the database) in the JSON output.",
+)
+@click.option(
+    "--tag/--no-tag", default=False, help="Include tag number in the JSON output."
+)
+@click.pass_context
+def command(ctx, input_file, output, exclude, annotations, tagid, tag):
+    """Convert an SDB file to JSON format."""
+    try:
+        exclude = [c.strip() for c in exclude.split(",") if c.strip()]
+        if "auto" in exclude:
+            exclude.remove("auto")
+            exclude.extend(["INDEXES", "STRINGTABLE"])
+        sdb2json_convert(
+            db=input_file,
+            output_stream=output,
+            exclude_tags=exclude,
+            with_annotations=annotations,
+            with_tagid=tagid,
+            with_tag=tag,
+        )
+    except Exception as e:
+        click.echo(f"Error converting SDB to JSON: {e}")
+        ctx.exit(1)

--- a/sdbtool/cli/sdb2xml.py
+++ b/sdbtool/cli/sdb2xml.py
@@ -7,6 +7,7 @@ COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
 
 import click
 from sdbtool.cli.types import SDB_DATABASE
+from sdbtool.cli.common import common_sdb_options, expand_exclude
 from sdbtool.sdb2xml import convert as sdb2xml_convert, XmlAnnotations
 
 
@@ -19,14 +20,6 @@ from sdbtool.sdb2xml import convert as sdb2xml_convert, XmlAnnotations
     help="Path to the output XML file, or '-' for stdout.",
 )
 @click.option(
-    "--exclude",
-    type=click.STRING,
-    default="",
-    metavar="TAG,TAG",
-    help="Exclude specified tags from the SDB file."
-    " Use 'auto' as an alias for 'INDEXES,STRINGTABLE'.",
-)
-@click.option(
     "--annotations",
     type=click.Choice(XmlAnnotations, case_sensitive=False),
     default=XmlAnnotations.Comment,
@@ -35,26 +28,15 @@ from sdbtool.sdb2xml import convert as sdb2xml_convert, XmlAnnotations
     " - Disabled: no annotations.\n"
     " - Comment: annotations as comments.",
 )
-@click.option(
-    "--tagid/--no-tagid",
-    default=False,
-    help="Include tagids (index in the database) in the XML output.",
-)
-@click.option(
-    "--tag/--no-tag", default=False, help="Include tag number in the XML output."
-)
+@common_sdb_options
 @click.pass_context
-def command(ctx, input_file, output, exclude, annotations, tagid, tag):
+def command(ctx, input_file, output, annotations, exclude, tagid, tag):
     """Convert an SDB file to XML format."""
     try:
-        exclude = [c.strip() for c in exclude.split(",") if c.strip()]
-        if "auto" in exclude:
-            exclude.remove("auto")
-            exclude.extend(["INDEXES", "STRINGTABLE"])
         sdb2xml_convert(
             db=input_file,
             output_stream=output,
-            exclude_tags=exclude,
+            exclude_tags=expand_exclude(exclude),
             annotations=annotations,
             with_tagid=tagid,
             with_tag=tag,

--- a/sdbtool/sdb2json.py
+++ b/sdbtool/sdb2json.py
@@ -101,7 +101,7 @@ class _FilteringVisitor(TagVisitor):
 
     def __init__(self, inner: JsonTagVisitor, exclude_tags: list[str]):
         self._inner = inner
-        self._exclude_tags = exclude_tags
+        self._exclude_tags = set(exclude_tags)
         self._skip_depth = 0
 
     def visit_list_begin(self, tag: Tag):
@@ -141,9 +141,8 @@ def convert(
         with_tag=with_tag,
     )
     root = db.root()
-    assert root is not None, (
-        "This is impossible, otherwise the previous exception would have been raised."
-    )
+    if root is None:
+        raise RuntimeError("Failed to get root tag from database.")
     root.accept(_FilteringVisitor(visitor, exclude_tags))
     json.dump(visitor.result(), output_stream, indent=2)
     output_stream.write("\n")

--- a/sdbtool/sdb2json.py
+++ b/sdbtool/sdb2json.py
@@ -2,7 +2,7 @@
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
 PURPOSE:     Convert SDB files to JSON format.
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 from sdbtool.apphelp import (
@@ -41,6 +41,8 @@ class JsonTagVisitor(TagVisitor):
         self._with_tag = with_tag
         self._root_meta: dict = {"file": input_filename}
         self._top_children: list = []
+        # Dummy root keeps the stack non-empty so visit/visit_list_begin can
+        # always do _stack[-1]["children"].append(...) without an empty-stack check.
         self._stack: list[dict] = [{"children": self._top_children}]
 
     def visit_list_begin(self, tag: Tag):

--- a/sdbtool/sdb2json.py
+++ b/sdbtool/sdb2json.py
@@ -1,0 +1,149 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     Convert SDB files to JSON format.
+COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+from sdbtool.apphelp import (
+    SdbDatabase,
+    TagVisitor,
+    TagType,
+    Tag,
+    tag_value_to_string,
+)
+import json
+
+
+def tagtype_to_jsontype(tag_type: TagType) -> str | None:
+    tagtype_map = {
+        TagType.BYTE: "byte",
+        TagType.WORD: "word",
+        TagType.DWORD: "dword",
+        TagType.QWORD: "qword",
+        TagType.STRINGREF: "string",
+        TagType.STRING: "string",
+        TagType.BINARY: "binary",
+    }
+    return tagtype_map.get(tag_type, None)
+
+
+class JsonTagVisitor(TagVisitor):
+    def __init__(
+        self,
+        input_filename: str,
+        with_annotations: bool,
+        with_tagid: bool,
+        with_tag: bool,
+    ):
+        self._with_annotations = with_annotations
+        self._with_tagid = with_tagid
+        self._with_tag = with_tag
+        self._root_meta: dict = {"file": input_filename}
+        self._top_children: list = []
+        self._stack: list[dict] = [{"children": self._top_children}]
+
+    def visit_list_begin(self, tag: Tag):
+        if tag.tag_id == 0:
+            # Root SDB node — its attributes go on the root dict itself
+            if self._with_tagid:
+                self._root_meta["tagid"] = tag.tag_id
+            if self._with_tag:
+                self._root_meta["tag_num"] = f"0x{tag.tag:x}"
+            return
+
+        node: dict = {"tag": tag.name}
+        if self._with_tagid:
+            node["tagid"] = tag.tag_id
+        if self._with_tag:
+            node["tag_num"] = f"0x{tag.tag:x}"
+        node["children"] = []
+        self._stack[-1]["children"].append(node)
+        self._stack.append(node)
+
+    def visit_list_end(self, tag: Tag):
+        if tag.tag_id == 0:
+            return
+        self._stack.pop()
+
+    def visit(self, tag: Tag):
+        if tag.type == TagType.NULL:
+            node: dict = {"tag": tag.name, "type": "null"}
+            if self._with_tagid:
+                node["tagid"] = tag.tag_id
+            if self._with_tag:
+                node["tag_num"] = f"0x{tag.tag:x}"
+            self._stack[-1]["children"].append(node)
+            return
+
+        typename = tagtype_to_jsontype(tag.type)
+        if typename is None:
+            raise ValueError(
+                f"Unknown json tag type: {tag.type.name} for tag {tag.name}"
+            )
+
+        value, comment = tag_value_to_string(tag)
+        node = {"tag": tag.name, "type": typename, "value": value}
+        if self._with_tagid:
+            node["tagid"] = tag.tag_id
+        if self._with_tag:
+            node["tag_num"] = f"0x{tag.tag:x}"
+        if self._with_annotations and comment is not None:
+            node["comment"] = comment
+        self._stack[-1]["children"].append(node)
+
+    def result(self) -> dict:
+        return {**self._root_meta, "children": self._top_children}
+
+
+class _FilteringVisitor(TagVisitor):
+    """Wraps JsonTagVisitor to apply tag exclusion."""
+
+    def __init__(self, inner: JsonTagVisitor, exclude_tags: list[str]):
+        self._inner = inner
+        self._exclude_tags = exclude_tags
+        self._skip_depth = 0
+
+    def visit_list_begin(self, tag: Tag):
+        if tag.name in self._exclude_tags:
+            self._skip_depth += 1
+        if self._skip_depth > 0:
+            return
+        self._inner.visit_list_begin(tag)
+
+    def visit_list_end(self, tag: Tag):
+        if self._skip_depth > 0:
+            if tag.name in self._exclude_tags:
+                self._skip_depth -= 1
+            return
+        self._inner.visit_list_end(tag)
+
+    def visit(self, tag: Tag):
+        if self._skip_depth > 0:
+            return
+        if tag.name in self._exclude_tags:
+            return
+        self._inner.visit(tag)
+
+
+def convert(
+    db: SdbDatabase,
+    output_stream,
+    exclude_tags: list[str],
+    with_annotations: bool,
+    with_tagid: bool,
+    with_tag: bool,
+):
+    visitor = JsonTagVisitor(
+        db.name,
+        with_annotations=with_annotations,
+        with_tagid=with_tagid,
+        with_tag=with_tag,
+    )
+    root = db.root()
+    assert root is not None, (
+        "This is impossible, otherwise the previous exception would have been raised."
+    )
+    root.accept(_FilteringVisitor(visitor, exclude_tags))
+    json.dump(visitor.result(), output_stream, indent=2)
+    output_stream.write("\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
 
 import click
 from click.testing import CliRunner
-from sdbtool.cli import attributes, sdb2xml, info, gui
+from sdbtool.cli import attributes, sdb2xml, sdb2json, info, gui
 from sdbtool.cli import sdbtool_command
 from sdbtool.cli.types import SDB_DATABASE
 from sdbtool.info import DatabaseInformation
@@ -193,6 +193,45 @@ def test_gui_command(tmp_path, monkeypatch):
         result = runner.invoke(sdbtool_command, ["gui", "test.nope"])
         assert result.exit_code == 1
         assert "Error launching GUI: File test.nope does not exist." in result.output
+
+
+def test_sdb2json_command(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sdb2json,
+        "sdb2json_convert",
+        lambda db,
+        output_stream,
+        exclude_tags,
+        with_annotations,
+        with_tagid,
+        with_tag: click.echo(f"nop:{exclude_tags}"),
+    )
+    runner = CliRunner()
+    db_file = str(TESTDATA_FOLDER / "all_tagtypes.sdb")
+    result = runner.invoke(sdbtool_command, ["sdb2json", db_file])
+    assert result.exit_code == 0
+    assert "nop:[]\n" == result.output
+    result = runner.invoke(
+        sdbtool_command, ["sdb2json", db_file, "--exclude", "XXX,YYY"]
+    )
+    assert result.exit_code == 0
+    assert "nop:['XXX', 'YYY']\n" == result.output
+    result = runner.invoke(sdbtool_command, ["sdb2json", db_file, "--exclude=auto"])
+    assert result.exit_code == 0
+    assert "nop:['INDEXES', 'STRINGTABLE']\n" == result.output
+
+
+def test_sdb2json_exception(tmp_path, monkeypatch):
+    def raise_value_error(*args, **kwargs):
+        raise ValueError("Test error")
+
+    monkeypatch.setattr(sdb2json, "sdb2json_convert", raise_value_error)
+    runner = CliRunner()
+    db_file = str(TESTDATA_FOLDER / "all_tagtypes.sdb")
+    result = runner.invoke(sdbtool_command, ["sdb2json", db_file])
+    assert result.exit_code == 1
+    assert "Error converting SDB to JSON" in result.output
+    assert "Test error" in result.output
 
 
 def test_sdb_database_param_type():

--- a/tests/test_sdb2json.py
+++ b/tests/test_sdb2json.py
@@ -380,7 +380,7 @@ def test_tagtype_to_jsontype():
 
 
 def test_JsonTagVisitor_invalid_visit(monkeypatch):
-    def mock_SdbOpenDatabase(path, type):
+    def mock_SdbOpenDatabase(path, path_type):
         return None
 
     monkeypatch.setattr(winapi, "SdbOpenDatabase", mock_SdbOpenDatabase)
@@ -398,6 +398,24 @@ def test_JsonTagVisitor_invalid_visit(monkeypatch):
     tag.tag_id = 1  # non-root so the branch is hit
     with pytest.raises(ValueError, match="Unknown json tag type: LIST for tag TestTag"):
         visitor.visit(tag)
+
+
+def test_convert_raises_when_root_is_none(monkeypatch):
+    def mock_SdbOpenDatabase(path, path_type):
+        return None
+
+    monkeypatch.setattr(winapi, "SdbOpenDatabase", mock_SdbOpenDatabase)
+
+    db = SdbDatabase("test.sdb", PathType.DOS_PATH)
+    with pytest.raises(RuntimeError, match="Failed to get root tag from database"):
+        sdb2json_convert(
+            db=db,
+            output_stream=io.StringIO(),
+            exclude_tags=[],
+            with_annotations=False,
+            with_tagid=False,
+            with_tag=False,
+        )
 
 
 def test_db_with_tagid_and_tag(all_tags_sdb):

--- a/tests/test_sdb2json.py
+++ b/tests/test_sdb2json.py
@@ -1,0 +1,413 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     Tests for the sdb2json module.
+COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+import io
+import json
+from pathlib import Path
+from sdbtool.sdb2json import (
+    JsonTagVisitor,
+    convert as sdb2json_convert,
+    tagtype_to_jsontype,
+)
+from sdbtool.apphelp import TAGID_ROOT, PathType, SdbDatabase, Tag, TagType, winapi
+import pytest
+
+TESTDATA_FOLDER = Path(__file__).parent / "data"
+
+ALL_TAGS_RESULT = """{
+  "file": "all_tagtypes.sdb",
+  "children": [
+    {
+      "tag": "DATABASE",
+      "children": [
+        {
+          "tag": "InvalidTag",
+          "children": []
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "null"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "byte",
+          "value": "255"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "word",
+          "value": "65535"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "dword",
+          "value": "4294967295"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "qword",
+          "value": "18446744073709551615"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "binary",
+          "value": "//////////8="
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "string",
+          "value": ""
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "string",
+          "value": ""
+        },
+        {
+          "tag": "DATABASE",
+          "children": []
+        },
+        {
+          "tag": "INCLUDE",
+          "type": "null"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "byte",
+          "value": "0"
+        },
+        {
+          "tag": "MATCH_MODE",
+          "type": "word",
+          "value": "0"
+        },
+        {
+          "tag": "SIZE",
+          "type": "dword",
+          "value": "0"
+        },
+        {
+          "tag": "BIN_FILE_VERSION",
+          "type": "qword",
+          "value": "0"
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "binary",
+          "value": "AAAAAAAAAAA="
+        },
+        {
+          "tag": "InvalidTag",
+          "type": "string",
+          "value": "val"
+        },
+        {
+          "tag": "NAME",
+          "type": "string",
+          "value": ""
+        },
+        {
+          "tag": "LIBRARY",
+          "children": [
+            {
+              "tag": "INDEX_TAG",
+              "type": "word",
+              "value": "14338",
+              "comment": "INDEX_TAG"
+            },
+            {
+              "tag": "INDEX_KEY",
+              "type": "word",
+              "value": "14339",
+              "comment": "INDEX_KEY"
+            },
+            {
+              "tag": "INDEX_FLAGS",
+              "type": "dword",
+              "value": "3",
+              "comment": "SHIMDB_INDEX_UNIQUE_KEY | SHIMDB_INDEX_TRAILING_CHARACTERS"
+            },
+            {
+              "tag": "GUEST_TARGET_PLATFORM",
+              "type": "dword",
+              "value": "17",
+              "comment": "X86 | ARM64"
+            },
+            {
+              "tag": "RUNTIME_PLATFORM",
+              "type": "dword",
+              "value": "34",
+              "comment": "AMD64 | 0x20"
+            }
+          ]
+        },
+        {
+          "tag": "PATCH",
+          "children": [
+            {
+              "tag": "APP",
+              "children": [
+                {
+                  "tag": "EXE",
+                  "children": [
+                    {
+                      "tag": "LINK_DATE",
+                      "type": "dword",
+                      "value": "0"
+                    },
+                    {
+                      "tag": "UPTO_LINK_DATE",
+                      "type": "dword",
+                      "value": "1",
+                      "comment": "1970-01-01 00:00:01 UTC"
+                    },
+                    {
+                      "tag": "FROM_LINK_DATE",
+                      "type": "dword",
+                      "value": "69922",
+                      "comment": "1970-01-01 19:25:22 UTC"
+                    }
+                  ]
+                },
+                {
+                  "tag": "TIME",
+                  "type": "qword",
+                  "value": "0"
+                },
+                {
+                  "tag": "TIME",
+                  "type": "qword",
+                  "value": "131560831927601799",
+                  "comment": "2017-11-25T11:33:12.7601799Z"
+                },
+                {
+                  "tag": "EXE_ID",
+                  "type": "binary",
+                  "value": ""
+                },
+                {
+                  "tag": "EXE_ID",
+                  "type": "binary",
+                  "value": "iHdmVSIRIhERIjNEVWZ3iA==",
+                  "comment": "{55667788-1122-1122-1122-334455667788}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"""
+
+STRIPPED_TAG_TAGID_RESULT = """{
+  "file": "all_tagtypes.sdb",
+  "tagid": 0,
+  "tag_num": "0x0",
+  "children": [
+    {
+      "tag": "DATABASE",
+      "tagid": 12,
+      "tag_num": "0x7001",
+      "children": [
+        {
+          "tag": "DATABASE",
+          "tagid": 78,
+          "tag_num": "0x7001",
+          "children": []
+        },
+        {
+          "tag": "INCLUDE",
+          "type": "null",
+          "tagid": 84,
+          "tag_num": "0x1001"
+        },
+        {
+          "tag": "MATCH_MODE",
+          "type": "word",
+          "value": "0",
+          "tagid": 90,
+          "tag_num": "0x3001"
+        },
+        {
+          "tag": "SIZE",
+          "type": "dword",
+          "value": "0",
+          "tagid": 94,
+          "tag_num": "0x4001"
+        },
+        {
+          "tag": "BIN_FILE_VERSION",
+          "type": "qword",
+          "value": "0",
+          "tagid": 100,
+          "tag_num": "0x5002"
+        },
+        {
+          "tag": "NAME",
+          "type": "string",
+          "value": "",
+          "tagid": 138,
+          "tag_num": "0x6001"
+        },
+        {
+          "tag": "LIBRARY",
+          "tagid": 144,
+          "tag_num": "0x7002",
+          "children": [
+            {
+              "tag": "INDEX_TAG",
+              "type": "word",
+              "value": "14338",
+              "tagid": 150,
+              "tag_num": "0x3802"
+            },
+            {
+              "tag": "INDEX_KEY",
+              "type": "word",
+              "value": "14339",
+              "tagid": 154,
+              "tag_num": "0x3803"
+            },
+            {
+              "tag": "INDEX_FLAGS",
+              "type": "dword",
+              "value": "3",
+              "tagid": 158,
+              "tag_num": "0x4016"
+            },
+            {
+              "tag": "GUEST_TARGET_PLATFORM",
+              "type": "dword",
+              "value": "17",
+              "tagid": 164,
+              "tag_num": "0x4023"
+            },
+            {
+              "tag": "RUNTIME_PLATFORM",
+              "type": "dword",
+              "value": "34",
+              "tagid": 170,
+              "tag_num": "0x4021"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def all_tags_sdb():
+    db = SdbDatabase(TESTDATA_FOLDER / "all_tagtypes.sdb")
+    assert db
+    yield db
+    db.close()
+
+
+def test_database(all_tags_sdb):
+    output = io.StringIO()
+    sdb2json_convert(
+        db=all_tags_sdb,
+        output_stream=output,
+        exclude_tags=[],
+        with_annotations=True,
+        with_tagid=False,
+        with_tag=False,
+    )
+    assert output.getvalue() == ALL_TAGS_RESULT
+
+
+def test_database_with_exclude_tags(all_tags_sdb):
+    output = io.StringIO()
+    sdb2json_convert(
+        db=all_tags_sdb,
+        output_stream=output,
+        exclude_tags=["PATCH", "APP", "BIN_FILE_VERSION", "TIME"],
+        with_annotations=True,
+        with_tagid=False,
+        with_tag=False,
+    )
+    data = json.loads(output.getvalue())
+    db_children = data["children"][0]["children"]
+    tags = [c["tag"] for c in db_children]
+    assert "PATCH" not in tags
+    assert "BIN_FILE_VERSION" not in tags
+    # LINK_DATE lives inside PATCH > APP > EXE which is excluded
+    assert all(
+        c["tag"] != "LINK_DATE"
+        for c in db_children
+    )
+
+
+def test_no_annotations(all_tags_sdb):
+    output = io.StringIO()
+    sdb2json_convert(
+        db=all_tags_sdb,
+        output_stream=output,
+        exclude_tags=[],
+        with_annotations=False,
+        with_tagid=False,
+        with_tag=False,
+    )
+    data = json.loads(output.getvalue())
+    library = next(
+        c for c in data["children"][0]["children"] if c.get("tag") == "LIBRARY"
+    )
+    index_tag = next(c for c in library["children"] if c["tag"] == "INDEX_TAG")
+    assert "comment" not in index_tag
+    index_flags = next(c for c in library["children"] if c["tag"] == "INDEX_FLAGS")
+    assert "comment" not in index_flags
+
+
+def test_tagtype_to_jsontype():
+    assert tagtype_to_jsontype(TagType.NULL) is None
+    assert tagtype_to_jsontype(TagType.LIST) is None
+    assert tagtype_to_jsontype(TagType.STRING) == "string"
+    assert tagtype_to_jsontype(TagType.STRINGREF) == "string"
+    assert tagtype_to_jsontype(TagType.BINARY) == "binary"
+    assert tagtype_to_jsontype(TagType.QWORD) == "qword"
+    assert tagtype_to_jsontype(TagType.DWORD) == "dword"
+    assert tagtype_to_jsontype(TagType.WORD) == "word"
+    assert tagtype_to_jsontype(TagType.BYTE) == "byte"
+
+
+def test_JsonTagVisitor_invalid_visit(monkeypatch):
+    def mock_SdbOpenDatabase(path, type):
+        return None
+
+    monkeypatch.setattr(winapi, "SdbOpenDatabase", mock_SdbOpenDatabase)
+
+    visitor = JsonTagVisitor(
+        "test.sdb",
+        with_annotations=True,
+        with_tagid=False,
+        with_tag=False,
+    )
+    db = SdbDatabase("test.sdb", PathType.DOS_PATH)
+    tag = Tag(db=db, tag_id=TAGID_ROOT)
+    tag.type = TagType.LIST
+    tag.name = "TestTag"
+    tag.tag_id = 1  # non-root so the branch is hit
+    with pytest.raises(ValueError, match="Unknown json tag type: LIST for tag TestTag"):
+        visitor.visit(tag)
+
+
+def test_db_with_tagid_and_tag(all_tags_sdb):
+    output = io.StringIO()
+    sdb2json_convert(
+        db=all_tags_sdb,
+        output_stream=output,
+        exclude_tags=["PATCH", "InvalidTag"],
+        with_annotations=False,
+        with_tagid=True,
+        with_tag=True,
+    )
+    assert output.getvalue() == STRIPPED_TAG_TAGID_RESULT

--- a/tests/test_sdb2json.py
+++ b/tests/test_sdb2json.py
@@ -2,7 +2,7 @@
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
 PURPOSE:     Tests for the sdb2json module.
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 import io


### PR DESCRIPTION
## Summary

- Adds a new `sdb2json` CLI command that converts SDB files to JSON format
- Mirrors `sdb2xml` with the same options: `--output`, `--exclude` (with `auto` alias), `--tagid`, `--tag`, and `--annotations`/`--no-annotations`
- JSON structure uses a tree of `{"tag": "NAME", "children": [...]}` for list nodes and `{"tag": "NAME", "type": "TYPE", "value": "..."}` for value nodes, with optional `"comment"` fields for human-readable annotations

## Test plan

- [x] All 30 existing tests continue to pass
- [x] 6 new tests in `tests/test_sdb2json.py` covering full output, tag exclusion, annotations toggle, type mapping, error handling, and tagid/tag flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)