### PR TITLE
Replace native apphelp.dll with a pure-Python implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ A tool for converting Microsoft Application Compatibility Database (SDB) files t
 ## Features<a id="features"></a>
 
 - Parses SDB files used by Windows for application compatibility.
-- Converts SDB data into readable XML.
+- Converts SDB data into readable XML or JSON format.
 - Dump file attributes in SDB-recognizable format
 - Useful for analysis, migration, or documentation.
+- Pure Python and cross-platform - no native `apphelp.dll` dependency.
 
 
 ## Getting Started<a id="getting-started"></a>
@@ -36,10 +37,12 @@ Sdbtool is available as [`sdbtool`](https://pypi.org/project/sdbtool/) on PyPI.
 Invoke sdbtool directly with [`uvx`](https://docs.astral.sh/uv/):
 
 ```shell
-uvx sdbtool sdb2xml your.sdb                    # Convert the file 'your.sdb' to xml, and print it to the console
-uvx sdbtool sdb2xml your.sdb --output your.xml  # Convert the file 'your.sdb' to xml, and write it to 'your.xml'
-uvx sdbtool attributes your.exe                 # Show the file attributes as recognized by apphelp in an XML-friendly format
-uvx sdbtool info your.sdb                       # Show some details about the SDB file (version, description, ...)
+uvx sdbtool sdb2xml your.sdb                        # Convert the file 'your.sdb' to xml, and print it to the console
+uvx sdbtool sdb2xml your.sdb --output your.xml      # Convert the file 'your.sdb' to xml, and write it to 'your.xml'
+uvx sdbtool sdb2json your.sdb                       # Convert the file 'your.sdb' to json, and print it to the console
+uvx sdbtool sdb2json your.sdb --output your.json    # Convert the file 'your.sdb' to json, and write it to 'your.json'
+uvx sdbtool attributes your.exe                     # Show the file attributes as recognized by apphelp in an XML-friendly format
+uvx sdbtool info your.sdb                           # Show some details about the SDB file (version, description, ...)
 ```
 
 Or install sdbtool with `uv` (recommended), `pip`, or `pipx`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sdbtool"
-description = "Interact with .sdb files using apphelp.dll"
 version = "0.8.0"
+description = "Interact with .sdb (application compatibility shim database) files"
 readme = "README.md"
 license = "MIT"
 authors = [
@@ -10,6 +10,7 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.2.1",
+    "pefile>=2024.8.26",
 ]
 keywords = ["sdb", "sdbtool", "sdb2xml", "shim", "apphelp", "appcompat", "shimeng"]
 classifiers = [
@@ -20,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Operating System :: Microsoft :: Windows",
+    "Operating System :: OS Independent",
     "Topic :: Utilities",
 ]
 

--- a/sdbtool/apphelp/__init__.py
+++ b/sdbtool/apphelp/__init__.py
@@ -2,14 +2,14 @@
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
 PURPOSE:     High level interface to the AppHelp API for reading SDB files.
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+COPYRIGHT:   Copyright 2025,2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
-from ctypes import c_void_p
 from enum import IntEnum, IntFlag
 from base64 import b64encode
 from uuid import UUID
 from . import winapi as apphelp
+from .sdb_reader import SdbFile
 from datetime import datetime, timezone
 from abc import ABC, abstractmethod
 from .tags import Win10Tags as Tags, tag_id_to_string
@@ -142,7 +142,7 @@ class Tag:
             self.name = tag_id_to_string(self.tag)
             self.type = get_tag_type(self.tag)
 
-    def _ensure_db_handle(self) -> c_void_p:
+    def _ensure_db_handle(self) -> SdbFile:
         """Ensures that the database handle is initialized."""
         if self.db._handle is None:
             raise ValueError("Database handle is not initialized")

--- a/sdbtool/apphelp/fileattr.py
+++ b/sdbtool/apphelp/fileattr.py
@@ -1,0 +1,399 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     Pure-Python re-implementation of the apphelp file-attribute API.
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+
+Reproduces the attributes returned by the (Windows) apphelp.dll
+SdbGetFileAttributes / SdbFormatAttribute pair, removing the native dependency.
+Based on ReactOS' sdbfileattr.c plus the additional attributes and formatting
+that modern Windows apphelp.dll produces. PE parsing uses the pefile package.
+"""
+
+from __future__ import annotations
+
+import binascii
+import os
+from datetime import datetime, timezone
+
+import pefile
+
+from sdbtool.apphelp.tags.Win10 import tag_id_to_string
+
+ATTRIBUTE_AVAILABLE = 0x1
+ATTRIBUTE_FAILED = 0x2
+
+# Tag ids (see sdbtagid.h / tags/Win10.py)
+TAG_SIZE = 0x4001
+TAG_CHECKSUM = 0x4003
+TAG_MODULE_TYPE = 0x4006
+TAG_VERDATEHI = 0x4007
+TAG_VERDATELO = 0x4008
+TAG_VERFILEOS = 0x4009
+TAG_VERFILETYPE = 0x400A
+TAG_PE_CHECKSUM = 0x400B
+TAG_VER_LANGUAGE = 0x4012
+TAG_LINKER_VERSION = 0x401C
+TAG_LINK_DATE = 0x401D
+TAG_UPTO_LINK_DATE = 0x401E
+TAG_EXE_WRAPPER = 0x4031
+TAG_FROM_LINK_DATE = 0x4033
+TAG_SIZE_OF_IMAGE = 0x4043
+TAG_CRC_CHECKSUM = 0x404A
+
+TAG_BIN_FILE_VERSION = 0x5002
+TAG_BIN_PRODUCT_VERSION = 0x5003
+TAG_UPTO_BIN_PRODUCT_VERSION = 0x5006
+TAG_UPTO_BIN_FILE_VERSION = 0x500D
+TAG_FROM_BIN_PRODUCT_VERSION = 0x5012
+TAG_FROM_BIN_FILE_VERSION = 0x5013
+TAG_FILESIZE = 0x5020
+
+TAG_COMPANY_NAME = 0x6009
+TAG_PRODUCT_NAME = 0x6010
+TAG_PRODUCT_VERSION = 0x6011
+TAG_FILE_DESCRIPTION = 0x6012
+TAG_FILE_VERSION = 0x6013
+TAG_ORIGINAL_FILENAME = 0x6014
+TAG_INTERNAL_NAME = 0x6015
+TAG_LEGAL_COPYRIGHT = 0x6016
+TAG_16BIT_DESCRIPTION = 0x6017
+TAG_16BIT_MODULE_NAME = 0x6020
+TAG_EXPORT_NAME = 0x6024
+TAG_UPTO_PRODUCT_VERSION = 0x6044
+TAG_UPTO_FILE_VERSION = 0x6045
+TAG_FROM_PRODUCT_VERSION = 0x6046
+TAG_FROM_FILE_VERSION = 0x6047
+
+# Module types (matches SdbFormatAttribute output)
+_MODTYPE_NONE = 0
+_MODTYPE_DOS = 1
+_MODTYPE_NE = 2
+_MODTYPE_PE = 3
+_MODTYPE_NAMES = {0: "NONE", 1: "DOS", 2: "WIN16", 3: "WIN32"}
+
+# Tags whose value is formatted in a special way by SdbFormatAttribute.
+_VERSION_TAGS = frozenset(
+    {
+        TAG_BIN_FILE_VERSION,
+        TAG_BIN_PRODUCT_VERSION,
+        TAG_UPTO_BIN_PRODUCT_VERSION,
+        TAG_UPTO_BIN_FILE_VERSION,
+        TAG_FROM_BIN_PRODUCT_VERSION,
+        TAG_FROM_BIN_FILE_VERSION,
+    }
+)
+_DATE_TAGS = frozenset({TAG_LINK_DATE, TAG_UPTO_LINK_DATE, TAG_FROM_LINK_DATE})
+_DECIMAL_TAGS = frozenset({TAG_SIZE, TAG_FILESIZE})
+
+# Language ids that apphelp reports as "Language Neutral".
+_NEUTRAL_LANGS = {0x0000, 0xFFFF}
+
+
+class AttrInfo:
+    """A single file attribute (mirrors the native ATTRINFO structure)."""
+
+    __slots__ = ("tag", "flags", "value")
+
+    def __init__(self, tag: int, flags: int, value=None):
+        self.tag = tag
+        self.flags = flags
+        self.value = value
+
+
+def _available(tag: int, value) -> AttrInfo:
+    return AttrInfo(tag, ATTRIBUTE_AVAILABLE, value)
+
+
+def _failed(tag: int) -> AttrInfo:
+    return AttrInfo(tag, ATTRIBUTE_FAILED, None)
+
+
+def _u32(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off : off + 4], "little")
+
+
+def _calculate_file_checksum(data: bytes) -> int:
+    """Port of apphelp's SdbpCalculateFileChecksum (a rolling 32-bit checksum)."""
+    size = len(data)
+    if size < 4:
+        return 0
+    if size >= 0x1000:
+        sz = 0x1000
+        off = (size - 0x1000) if size < 0x1200 else 0x200
+    else:
+        off = 0
+        sz = size
+    checks = 0
+    for n in range(sz // 4):
+        checks = (checks + _u32(data, off + n * 4)) & 0xFFFFFFFF
+        carry = 0x80000000 if (checks & 1) else 0
+        checks = (checks >> 1) | carry
+    return checks
+
+
+def _crc_checksum(data: bytes) -> int:
+    """Port of apphelp's CRC_CHECKSUM: a zlib CRC-32 over a head+tail sample.
+
+    The file is sampled into a 0x2000-byte buffer: the first min(size, 0x2000)
+    bytes, with the upper half overwritten by the last 0x1000 bytes when the
+    file is larger than 0x2000. The CRC covers 0x1000 bytes for files up to
+    0x1000 bytes, otherwise 0x2000 bytes (zero-padded).
+    """
+    size = len(data)
+    if size == 0:
+        return 0
+    buf = bytearray(0x2000)
+    n1 = min(size, 0x2000)
+    buf[0:n1] = data[0:n1]
+    if size > 0x2000:
+        buf[0x1000:0x2000] = data[size - 0x1000 : size]
+    clen = 0x1000 if size <= 0x1000 else 0x2000
+    return binascii.crc32(bytes(buf[0:clen])) & 0xFFFFFFFF
+
+
+def _module_type(data: bytes) -> int:
+    """Port of apphelp's SdbpGetModuleType (DOS / NE / PE detection)."""
+    if len(data) < 2 or data[0:2] != b"MZ":
+        return _MODTYPE_NONE
+    if len(data) < 0x40:
+        return _MODTYPE_DOS
+    e_lfanew = _u32(data, 0x3C)
+    if len(data) < e_lfanew + 2:
+        return _MODTYPE_DOS
+    sig2 = data[e_lfanew : e_lfanew + 2]
+    if sig2 in (b"NE", b"LE"):
+        return _MODTYPE_NE
+    if len(data) >= e_lfanew + 4 and data[e_lfanew : e_lfanew + 4] == b"PE\x00\x00":
+        return _MODTYPE_PE
+    return _MODTYPE_DOS
+
+
+def _decode(value) -> str:
+    if isinstance(value, bytes):
+        return value.decode("latin-1", "replace")
+    return value
+
+
+def _version_resource(pe: "pefile.PE"):
+    """Return (fixed_info, strings_dict, language) or (None, {}, None)."""
+    fixed = None
+    if getattr(pe, "VS_FIXEDFILEINFO", None):
+        fixed = pe.VS_FIXEDFILEINFO[0]
+
+    language = None
+    strings: dict[str, str] = {}
+    for fileinfo in getattr(pe, "FileInfo", []) or []:
+        for entry in fileinfo:
+            if getattr(entry, "Key", None) == b"VarFileInfo" and hasattr(entry, "Var"):
+                for var in entry.Var:
+                    trans = getattr(var, "entry", {}).get(b"Translation")
+                    if trans and language is None:
+                        language = int(trans.split()[0], 16) & 0xFFFF
+            if getattr(entry, "Key", None) == b"StringFileInfo" and hasattr(
+                entry, "StringTable"
+            ):
+                for st in entry.StringTable:
+                    for key, val in st.entries.items():
+                        strings[_decode(key)] = _decode(val)
+    return fixed, strings, language
+
+
+def get_file_attributes(path: str | os.PathLike) -> list[AttrInfo]:
+    """Return the list of file attributes for ``path`` (mirrors SdbGetFileAttributes)."""
+    with open(os.fspath(path), "rb") as fp:
+        data = fp.read()
+
+    size = len(data)
+    module_type = _module_type(data)
+
+    attrs: list[AttrInfo] = []
+
+    # Always-available, file-level attributes.
+    attrs.append(_available(TAG_SIZE, size))
+    attrs.append(_available(TAG_FILESIZE, size))
+
+    pe = None
+    if module_type == _MODTYPE_PE:
+        try:
+            pe = pefile.PE(data=data, fast_load=False)
+        except pefile.PEFormatError:
+            pe = None
+
+    if pe is not None:
+        attrs.append(_available(TAG_SIZE_OF_IMAGE, pe.OPTIONAL_HEADER.SizeOfImage))
+    else:
+        attrs.append(_failed(TAG_SIZE_OF_IMAGE))
+
+    if size:
+        attrs.append(_available(TAG_CHECKSUM, _calculate_file_checksum(data)))
+    else:
+        attrs.append(_failed(TAG_CHECKSUM))
+
+    fixed, strings, language = (None, {}, None)
+    if pe is not None:
+        fixed, strings, language = _version_resource(pe)
+
+    def bin_version(ms: int, ls: int) -> int:
+        return ((ms & 0xFFFFFFFF) << 32) | (ls & 0xFFFFFFFF)
+
+    if fixed is not None:
+        file_ver = bin_version(fixed.FileVersionMS, fixed.FileVersionLS)
+        prod_ver = bin_version(fixed.ProductVersionMS, fixed.ProductVersionLS)
+    else:
+        file_ver = prod_ver = None
+
+    def ver_attr(tag: int, value):
+        return _available(tag, value) if value is not None else _failed(tag)
+
+    def str_attr(tag: int, key: str):
+        val = strings.get(key)
+        return _available(tag, val) if val is not None else _failed(tag)
+
+    attrs.append(ver_attr(TAG_BIN_FILE_VERSION, file_ver))
+    attrs.append(ver_attr(TAG_BIN_PRODUCT_VERSION, prod_ver))
+    attrs.append(str_attr(TAG_PRODUCT_VERSION, "ProductVersion"))
+    attrs.append(str_attr(TAG_FILE_DESCRIPTION, "FileDescription"))
+    attrs.append(str_attr(TAG_COMPANY_NAME, "CompanyName"))
+    attrs.append(str_attr(TAG_PRODUCT_NAME, "ProductName"))
+    attrs.append(str_attr(TAG_FILE_VERSION, "FileVersion"))
+    attrs.append(str_attr(TAG_ORIGINAL_FILENAME, "OriginalFilename"))
+    attrs.append(str_attr(TAG_INTERNAL_NAME, "InternalName"))
+    attrs.append(str_attr(TAG_LEGAL_COPYRIGHT, "LegalCopyright"))
+
+    if fixed is not None:
+        attrs.append(_available(TAG_VERDATEHI, fixed.FileDateMS))
+        attrs.append(_available(TAG_VERDATELO, fixed.FileDateLS))
+        attrs.append(_available(TAG_VERFILEOS, fixed.FileOS))
+        attrs.append(_available(TAG_VERFILETYPE, fixed.FileType))
+    else:
+        attrs.append(_failed(TAG_VERDATEHI))
+        attrs.append(_failed(TAG_VERDATELO))
+        attrs.append(_failed(TAG_VERFILEOS))
+        attrs.append(_failed(TAG_VERFILETYPE))
+
+    if module_type != _MODTYPE_NONE:
+        attrs.append(_available(TAG_MODULE_TYPE, module_type))
+    else:
+        attrs.append(_failed(TAG_MODULE_TYPE))
+
+    if pe is not None:
+        oh = pe.OPTIONAL_HEADER
+        fh = pe.FILE_HEADER
+        attrs.append(_available(TAG_PE_CHECKSUM, oh.CheckSum))
+        attrs.append(
+            _available(
+                TAG_LINKER_VERSION,
+                ((oh.MajorImageVersion & 0xFFFF) << 16)
+                | (oh.MinorImageVersion & 0xFFFF),
+            )
+        )
+    else:
+        attrs.append(_failed(TAG_PE_CHECKSUM))
+        attrs.append(_failed(TAG_LINKER_VERSION))
+
+    # 16-bit (NE) only.
+    attrs.append(_failed(TAG_16BIT_DESCRIPTION))
+    attrs.append(_failed(TAG_16BIT_MODULE_NAME))
+
+    attrs.append(ver_attr(TAG_FROM_BIN_FILE_VERSION, file_ver))
+    attrs.append(ver_attr(TAG_FROM_BIN_PRODUCT_VERSION, prod_ver))
+    attrs.append(ver_attr(TAG_UPTO_BIN_FILE_VERSION, file_ver))
+    attrs.append(ver_attr(TAG_UPTO_BIN_PRODUCT_VERSION, prod_ver))
+
+    if pe is not None:
+        timestamp = pe.FILE_HEADER.TimeDateStamp
+        attrs.append(_available(TAG_LINK_DATE, timestamp))
+        attrs.append(_available(TAG_FROM_LINK_DATE, timestamp))
+        attrs.append(_available(TAG_UPTO_LINK_DATE, timestamp))
+    else:
+        attrs.append(_failed(TAG_LINK_DATE))
+        attrs.append(_failed(TAG_FROM_LINK_DATE))
+        attrs.append(_failed(TAG_UPTO_LINK_DATE))
+
+    export_name = None
+    if pe is not None and hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):
+        name = getattr(pe.DIRECTORY_ENTRY_EXPORT.struct, "Name", 0)
+        raw = pe.get_string_at_rva(name) if name else None
+        if raw:
+            export_name = _decode(raw)
+    attrs.append(
+        _available(TAG_EXPORT_NAME, export_name)
+        if export_name is not None
+        else _failed(TAG_EXPORT_NAME)
+    )
+
+    if pe is not None and language is not None:
+        attrs.append(_available(TAG_VER_LANGUAGE, language))
+    else:
+        attrs.append(_failed(TAG_VER_LANGUAGE))
+
+    if pe is not None:
+        attrs.append(_available(TAG_EXE_WRAPPER, 0))
+    else:
+        attrs.append(_failed(TAG_EXE_WRAPPER))
+
+    attrs.append(_available(TAG_CRC_CHECKSUM, _crc_checksum(data)))
+
+    attrs.append(str_attr(TAG_FROM_PRODUCT_VERSION, "ProductVersion"))
+    attrs.append(str_attr(TAG_UPTO_PRODUCT_VERSION, "ProductVersion"))
+    attrs.append(str_attr(TAG_FROM_FILE_VERSION, "FileVersion"))
+    attrs.append(str_attr(TAG_UPTO_FILE_VERSION, "FileVersion"))
+
+    return attrs
+
+
+def _format_language(value: int) -> str:
+    if value in _NEUTRAL_LANGS:
+        name = "Language Neutral"
+    else:
+        name = _LANGUAGE_NAMES.get(value, "Language Neutral")
+    return f"{name} [{value:#x}]"
+
+
+def _format_value(tag: int, value) -> str:
+    if tag in _DECIMAL_TAGS:
+        return str(value)
+    if tag in _VERSION_TAGS:
+        return "%d.%d.%d.%d" % (
+            (value >> 48) & 0xFFFF,
+            (value >> 32) & 0xFFFF,
+            (value >> 16) & 0xFFFF,
+            value & 0xFFFF,
+        )
+    if tag in _DATE_TAGS:
+        dt = datetime.fromtimestamp(value, tz=timezone.utc)
+        return dt.strftime("%m/%d/%Y %H:%M:%S")
+    if tag == TAG_VER_LANGUAGE:
+        return _format_language(value)
+    if tag == TAG_MODULE_TYPE:
+        return _MODTYPE_NAMES.get(value, "NONE")
+    if isinstance(value, str):
+        return value
+    return f"0x{value:X}"
+
+
+def format_attribute(attr: AttrInfo) -> str:
+    """Format an attribute as ``NAME="value"`` (mirrors SdbFormatAttribute)."""
+    if not (attr.flags & ATTRIBUTE_AVAILABLE):
+        name = tag_id_to_string(attr.tag)
+        raise ValueError(f"Failed to format attribute ({name})")
+    name = tag_id_to_string(attr.tag)
+    return f'{name}="{_format_value(attr.tag, attr.value)}"'
+
+
+# A subset of the Windows language-name table. apphelp formats the LANGID using
+# the OS language list; common entries are reproduced here, with everything else
+# (and the neutral ids) reported as "Language Neutral".
+_LANGUAGE_NAMES = {
+    0x0409: "English (United States)",
+    0x0809: "English (United Kingdom)",
+    0x0413: "Dutch (Netherlands)",
+    0x0407: "German (Germany)",
+    0x040C: "French (France)",
+    0x0410: "Italian (Italy)",
+    0x040A: "Spanish (Spain)",
+    0x0419: "Russian (Russia)",
+    0x0411: "Japanese (Japan)",
+    0x0804: "Chinese (Simplified, China)",
+}

--- a/sdbtool/apphelp/fileattr.py
+++ b/sdbtool/apphelp/fileattr.py
@@ -175,6 +175,19 @@ def _decode(value) -> str:
     return value
 
 
+def _export_name(pe: "pefile.PE") -> str | None:
+    """Return the export directory name of ``pe``, or ``None`` if absent."""
+    if not hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):
+        return None
+    name_rva = getattr(pe.DIRECTORY_ENTRY_EXPORT.struct, "Name", 0)
+    if not name_rva:
+        return None
+    raw = pe.get_string_at_rva(name_rva)
+    if not raw:
+        return None
+    return _decode(raw)
+
+
 def _version_resource(pe: "pefile.PE"):
     """Return (fixed_info, strings_dict, language) or (None, {}, None)."""
     fixed = None
@@ -279,7 +292,6 @@ def get_file_attributes(path: str | os.PathLike) -> list[AttrInfo]:
 
     if pe is not None:
         oh = pe.OPTIONAL_HEADER
-        fh = pe.FILE_HEADER
         attrs.append(_available(TAG_PE_CHECKSUM, oh.CheckSum))
         attrs.append(
             _available(
@@ -311,12 +323,7 @@ def get_file_attributes(path: str | os.PathLike) -> list[AttrInfo]:
         attrs.append(_failed(TAG_FROM_LINK_DATE))
         attrs.append(_failed(TAG_UPTO_LINK_DATE))
 
-    export_name = None
-    if pe is not None and hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):
-        name = getattr(pe.DIRECTORY_ENTRY_EXPORT.struct, "Name", 0)
-        raw = pe.get_string_at_rva(name) if name else None
-        if raw:
-            export_name = _decode(raw)
+    export_name = _export_name(pe) if pe is not None else None
     attrs.append(
         _available(TAG_EXPORT_NAME, export_name)
         if export_name is not None

--- a/sdbtool/apphelp/sdb_reader.py
+++ b/sdbtool/apphelp/sdb_reader.py
@@ -1,0 +1,292 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     Pure-Python reader for SDB (shim database) files.
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+
+This is a pure-Python port of the SDB reading functions from the ReactOS
+apphelp module (sdbread.c / sdbapi.c), removing the dependency on the native
+apphelp.dll. The function names and semantics mirror the original Win32 API.
+"""
+
+from __future__ import annotations
+
+# Tag type nibble (high 4 bits of a TAG)
+TAG_TYPE_MASK = 0xF000
+TAG_TYPE_NULL = 0x1000
+TAG_TYPE_BYTE = 0x2000
+TAG_TYPE_WORD = 0x3000
+TAG_TYPE_DWORD = 0x4000
+TAG_TYPE_QWORD = 0x5000
+TAG_TYPE_STRINGREF = 0x6000
+TAG_TYPE_LIST = 0x7000
+TAG_TYPE_STRING = 0x8000
+TAG_TYPE_BINARY = 0x9000
+
+TAG_NULL = 0x0
+TAGID_NULL = 0x0
+TAGID_ROOT = 0x0
+_TAGID_ROOT = 12  # First tag follows the 12-byte header
+
+_SIZEOF_TAG = 2
+_SIZEOF_DWORD = 4
+
+# Tags needed to resolve the string table and the database name / id.
+_TAG_NAME = 0x6001
+_TAG_DATABASE = 0x7001
+_TAG_STRINGTABLE = 0x7801
+_TAG_DATABASE_ID = 0x9007
+
+# Fixed sizes for the data types with a fixed size, indexed by (type >> 12) - 1.
+_FIXED_SIZES = (0, 1, 2, 4, 8, 4)  # NULL, BYTE, WORD, DWORD, QWORD, STRINGREF
+
+
+class SdbFile:
+    """An opened shim database, holding the raw bytes and cached metadata.
+
+    Instances are returned by :func:`SdbOpenDatabase` and act as the opaque
+    handle (``PDB``) that the rest of the reading API operates on.
+    """
+
+    def __init__(self, data: bytes, major: int, minor: int):
+        self.data = data
+        self.size = len(data)
+        self.major = major
+        self.minor = minor
+        self.stringtable: int = TAGID_NULL
+        self.database_id: bytes | None = None
+        self.database_name: str | None = None
+
+
+def SdbpReadData(pdb: SdbFile, offset: int, num: int) -> bytes | None:
+    """Read ``num`` bytes at ``offset``, or ``None`` on overflow / out of bounds."""
+    end = offset + num
+    # Either overflow or no data to read
+    if end <= offset:
+        return None
+    if pdb.size < end:
+        return None
+    return pdb.data[offset:end]
+
+
+def _read_uint(pdb: SdbFile, offset: int, num: int) -> int | None:
+    raw = SdbpReadData(pdb, offset, num)
+    if raw is None:
+        return None
+    return int.from_bytes(raw, "little")
+
+
+def SdbGetTagFromTagID(pdb: SdbFile, tagid: int) -> int:
+    """Return the TAG stored at ``tagid``, or :data:`TAG_NULL` on failure."""
+    value = _read_uint(pdb, tagid, _SIZEOF_TAG)
+    return TAG_NULL if value is None else value
+
+
+def SdbGetTagDataSize(pdb: SdbFile, tagid: int) -> int:
+    """Return the size in bytes of the data stored at ``tagid``."""
+    ttype = SdbGetTagFromTagID(pdb, tagid) & TAG_TYPE_MASK
+    if ttype == TAG_NULL:
+        return 0
+
+    if ttype <= TAG_TYPE_STRINGREF:
+        return _FIXED_SIZES[(ttype >> 12) - 1]
+
+    # Dynamically-sized tag (list / string / binary): the size follows the tag.
+    size = _read_uint(pdb, tagid + _SIZEOF_TAG, _SIZEOF_DWORD)
+    return 0 if size is None else size
+
+
+def _sdbp_get_tag_size(pdb: SdbFile, tagid: int) -> int:
+    """Total on-disk size of the tag at ``tagid`` (tag header + data).
+
+    Tag data is padded to a 2-byte (WORD) boundary on disk, so e.g. a BYTE tag
+    occupies a 2-byte data slot (the trailing pad byte is uninitialized). This
+    rounding is required to correctly walk databases written by apphelp.
+    """
+    ttype = SdbGetTagFromTagID(pdb, tagid) & TAG_TYPE_MASK
+    if ttype == TAG_NULL:
+        return 0
+
+    size = (SdbGetTagDataSize(pdb, tagid) + 1) & ~1
+    if ttype <= TAG_TYPE_STRINGREF:
+        return size + _SIZEOF_TAG
+    return size + _SIZEOF_TAG + _SIZEOF_DWORD
+
+
+def SdbGetFirstChild(pdb: SdbFile, parent: int) -> int:
+    """Return the TAGID of the first child of ``parent`` (or :data:`TAGID_NULL`)."""
+    if parent == TAGID_ROOT:
+        # header-only database: no tags
+        if pdb.size <= _TAGID_ROOT:
+            return TAGID_NULL
+        return _TAGID_ROOT
+
+    # Only list tags can have children.
+    if (SdbGetTagFromTagID(pdb, parent) & TAG_TYPE_MASK) != TAG_TYPE_LIST:
+        return TAGID_NULL
+
+    # An empty list has no children. (Native Windows apphelp.dll returns NULL
+    # here; ReactOS' sdbread.c omits this check and relies on the caller.)
+    if SdbGetTagDataSize(pdb, parent) == 0:
+        return TAGID_NULL
+
+    return parent + _SIZEOF_TAG + _SIZEOF_DWORD
+
+
+def SdbGetNextChild(pdb: SdbFile, parent: int, prev_child: int) -> int:
+    """Return the TAGID of the child after ``prev_child`` (or :data:`TAGID_NULL`)."""
+    prev_child_size = _sdbp_get_tag_size(pdb, prev_child)
+    if prev_child_size == 0:
+        return TAGID_NULL
+
+    next_child = prev_child + prev_child_size
+    if next_child >= pdb.size:
+        return TAGID_NULL
+
+    if parent == TAGID_ROOT:
+        return next_child
+
+    parent_size = _sdbp_get_tag_size(pdb, parent)
+    if parent_size == 0:
+        return TAGID_NULL
+
+    # Specified parent has no more children
+    if next_child >= parent + parent_size:
+        return TAGID_NULL
+
+    return next_child
+
+
+def SdbFindFirstTag(pdb: SdbFile, parent: int, tag: int) -> int:
+    """Return the TAGID of the first child of ``parent`` whose TAG equals ``tag``."""
+    it = SdbGetFirstChild(pdb, parent)
+    while it != TAGID_NULL:
+        if SdbGetTagFromTagID(pdb, it) == tag:
+            return it
+        it = SdbGetNextChild(pdb, parent, it)
+    return TAGID_NULL
+
+
+def _check_type(pdb: SdbFile, tagid: int, ttype: int) -> bool:
+    tag = SdbGetTagFromTagID(pdb, tagid)
+    if tag == TAG_NULL:
+        return False
+    return (tag & TAG_TYPE_MASK) == ttype
+
+
+def SdbReadBYTETag(pdb: SdbFile, tagid: int, default: int = 0) -> int:
+    if _check_type(pdb, tagid, TAG_TYPE_BYTE):
+        value = _read_uint(pdb, tagid + _SIZEOF_TAG, 1)
+        if value is not None:
+            return value
+    return default
+
+
+def SdbReadWORDTag(pdb: SdbFile, tagid: int, default: int = 0) -> int:
+    if _check_type(pdb, tagid, TAG_TYPE_WORD):
+        value = _read_uint(pdb, tagid + _SIZEOF_TAG, 2)
+        if value is not None:
+            return value
+    return default
+
+
+def SdbReadDWORDTag(pdb: SdbFile, tagid: int, default: int = 0) -> int:
+    if _check_type(pdb, tagid, TAG_TYPE_DWORD):
+        value = _read_uint(pdb, tagid + _SIZEOF_TAG, 4)
+        if value is not None:
+            return value
+    return default
+
+
+def SdbReadQWORDTag(pdb: SdbFile, tagid: int, default: int = 0) -> int:
+    if _check_type(pdb, tagid, TAG_TYPE_QWORD):
+        value = _read_uint(pdb, tagid + _SIZEOF_TAG, 8)
+        if value is not None:
+            return value
+    return default
+
+
+def SdbReadBinaryTag(pdb: SdbFile, tagid: int) -> bytes:
+    """Return the raw bytes of a binary tag (empty bytes for an empty tag)."""
+    if not _check_type(pdb, tagid, TAG_TYPE_BINARY):
+        raise ValueError(f"Tag 0x{tagid:x} is not a binary tag")
+    data_size = _read_uint(pdb, tagid + _SIZEOF_TAG, _SIZEOF_DWORD)
+    if data_size is None:
+        raise ValueError(f"Failed to read binary tag 0x{tagid:x}")
+    if data_size == 0:
+        return b""
+    raw = SdbpReadData(pdb, tagid + _SIZEOF_TAG + _SIZEOF_DWORD, data_size)
+    if raw is None:
+        raise ValueError(f"Failed to read binary tag 0x{tagid:x}")
+    return raw
+
+
+def SdbGetStringTagPtr(pdb: SdbFile, tagid: int) -> str | None:
+    """Return the string for a STRING / STRINGREF tag, or ``None`` on failure."""
+    tag = SdbGetTagFromTagID(pdb, tagid)
+    if tag == TAG_NULL:
+        return None
+
+    ttype = tag & TAG_TYPE_MASK
+    if ttype == TAG_TYPE_STRINGREF:
+        # No string table: all references are invalid.
+        if pdb.stringtable == TAGID_NULL:
+            return None
+        # A STRINGREF stores the offset of the string relative to the table.
+        stored = _read_uint(pdb, tagid + _SIZEOF_TAG, _SIZEOF_DWORD)
+        if stored is None:
+            return None
+        offset = pdb.stringtable + stored + _SIZEOF_TAG + _SIZEOF_DWORD
+    elif ttype == TAG_TYPE_STRING:
+        offset = tagid + _SIZEOF_TAG + _SIZEOF_DWORD
+    else:
+        return None
+
+    # The byte size (including the terminating NUL) precedes the string data.
+    size = _read_uint(pdb, offset - _SIZEOF_DWORD, _SIZEOF_DWORD)
+    if size is None:
+        return None
+    raw = SdbpReadData(pdb, offset, size)
+    if raw is None:
+        return None
+    return raw.decode("utf-16-le").rstrip("\x00")
+
+
+def _resolve_metadata(pdb: SdbFile) -> None:
+    """Cache the string table offset, database id and name (as done on open)."""
+    pdb.stringtable = SdbFindFirstTag(pdb, TAGID_ROOT, _TAG_STRINGTABLE)
+
+    root = SdbFindFirstTag(pdb, TAGID_ROOT, _TAG_DATABASE)
+    if root != TAGID_NULL:
+        id_tag = SdbFindFirstTag(pdb, root, _TAG_DATABASE_ID)
+        if id_tag != TAGID_NULL:
+            try:
+                data = SdbReadBinaryTag(pdb, id_tag)
+            except ValueError:
+                data = b""
+            if len(data) == 16:
+                pdb.database_id = data
+        name_tag = SdbFindFirstTag(pdb, root, _TAG_NAME)
+        if name_tag != TAGID_NULL:
+            pdb.database_name = SdbGetStringTagPtr(pdb, name_tag)
+
+
+def SdbOpenDatabase(path: str) -> SdbFile | None:
+    """Open and validate a shim database file. Returns ``None`` on failure."""
+    try:
+        with open(path, "rb") as fp:
+            data = fp.read()
+    except OSError:
+        return None
+
+    if len(data) < 12 or data[8:12] != b"sdbf":
+        return None
+
+    major = int.from_bytes(data[0:4], "little")
+    minor = int.from_bytes(data[4:8], "little")
+    if major not in (2, 3):
+        return None
+
+    pdb = SdbFile(data, major, minor)
+    _resolve_metadata(pdb)
+    return pdb

--- a/sdbtool/apphelp/sdb_reader.py
+++ b/sdbtool/apphelp/sdb_reader.py
@@ -249,7 +249,11 @@ def SdbGetStringTagPtr(pdb: SdbFile, tagid: int) -> str | None:
     raw = SdbpReadData(pdb, offset, size)
     if raw is None:
         return None
-    return raw.decode("utf-16-le").rstrip("\x00")
+    try:
+        return raw.decode("utf-16-le").rstrip("\x00")
+    except UnicodeDecodeError:
+        # Corrupt / malformed string data: treat as a read failure.
+        return None
 
 
 def _resolve_metadata(pdb: SdbFile) -> None:

--- a/sdbtool/apphelp/winapi.py
+++ b/sdbtool/apphelp/winapi.py
@@ -1,289 +1,72 @@
 """
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
-PURPOSE:     winapi interface to the AppHelp API for reading SDB files.
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+PURPOSE:     Low-level interface for reading SDB files.
+COPYRIGHT:   Copyright 2025,2026 Mark Jansen <mark.jansen@reactos.org>
+
+This is a thin facade over the pure-Python SDB reader (sdb_reader.py). It keeps
+the historical apphelp-style function names used by the high-level interface,
+but no longer depends on the native apphelp.dll.
 """
 
-from ctypes import (
-    byref,
-    c_uint8,
-    create_unicode_buffer,
-    windll,
-    c_void_p,
-    c_uint16,
-    c_uint32,
-    c_wchar_p,
-    POINTER,
-    pointer,
-    c_ubyte,
-    c_uint64,
-    Structure,
-    Union,
-)
-
-from sdbtool.apphelp.tags.Win10 import tag_id_to_string
-
-APPHELP = windll.apphelp
-
-# PDB WINAPI SdbOpenDatabase(LPCWSTR path, PATH_TYPE type);
-APPHELP.SdbOpenDatabase.argtypes = [c_wchar_p, c_uint32]
-APPHELP.SdbOpenDatabase.restype = c_void_p
-
-# void WINAPI SdbCloseDatabase(PDB);
-APPHELP.SdbCloseDatabase.argtypes = [c_void_p]
-
-# TAGID WINAPI SdbGetFirstChild(PDB pdb, TAGID parent);
-APPHELP.SdbGetFirstChild.argtypes = [c_void_p, c_uint32]
-APPHELP.SdbGetFirstChild.restype = c_uint32
-
-# TAGID WINAPI SdbGetNextChild(PDB pdb, TAGID parent, TAGID prev_child);
-APPHELP.SdbGetNextChild.argtypes = [c_void_p, c_uint32, c_uint32]
-APPHELP.SdbGetNextChild.restype = c_uint32
-
-# TAG WINAPI SdbGetTagFromTagID(PDB pdb, TAGID tagid);
-APPHELP.SdbGetTagFromTagID.argtypes = [c_void_p, c_uint32]
-APPHELP.SdbGetTagFromTagID.restype = c_uint16
-
-# BYTE WINAPI SdbReadBYTETag(PDB pdb, TAGID tagid, BYTE ret);
-APPHELP.SdbReadBYTETag.argtypes = [c_void_p, c_uint32, c_uint8]
-APPHELP.SdbReadBYTETag.restype = c_uint8
-
-# WORD WINAPI SdbReadWORDTag(PDB pdb, TAGID tagid, WORD ret);
-APPHELP.SdbReadWORDTag.argtypes = [c_void_p, c_uint32, c_uint16]
-APPHELP.SdbReadWORDTag.restype = c_uint16
-
-# DWORD WINAPI SdbReadDWORDTag(PDB pdb, TAGID tagid, DWORD ret);
-APPHELP.SdbReadDWORDTag.argtypes = [c_void_p, c_uint32, c_uint32]
-APPHELP.SdbReadDWORDTag.restype = c_uint32
-
-# QWORD WINAPI SdbReadQWORDTag(PDB pdb, TAGID tagid, QWORD ret);
-APPHELP.SdbReadQWORDTag.argtypes = [c_void_p, c_uint32, c_uint64]
-APPHELP.SdbReadQWORDTag.restype = c_uint64
-
-# DWORD WINAPI SdbGetTagDataSize(PDB pdb, TAGID tagid);
-APPHELP.SdbGetTagDataSize.argtypes = [c_void_p, c_uint32]
-APPHELP.SdbGetTagDataSize.restype = c_uint32
-
-# BOOL WINAPI SdbReadBinaryTag(PDB pdb, TAGID tagid, PBYTE buffer, DWORD size);
-APPHELP.SdbReadBinaryTag.argtypes = [c_void_p, c_uint32, POINTER(c_ubyte), c_uint32]
-APPHELP.SdbReadBinaryTag.restype = c_uint32
-
-# LPWSTR WINAPI SdbGetStringTagPtr(PDB pdb, TAGID tagid);
-APPHELP.SdbGetStringTagPtr.argtypes = [c_void_p, c_uint32]
-APPHELP.SdbGetStringTagPtr.restype = c_wchar_p
+from sdbtool.apphelp import sdb_reader
+from sdbtool.apphelp.sdb_reader import SdbFile
 
 
-# typedef struct tagATTRINFO {
-#   TAG   tAttrID;
-#   DWORD dwFlags;
-#   union {
-#     ULONGLONG ullAttr;
-#     DWORD     dwAttr;
-#     TCHAR     *lpAttr;
-#   };
-# } ATTRINFO, *PATTRINFO;
+def SdbOpenDatabase(path: str, path_type: int = 0) -> SdbFile | None:
+    """Open a database at the specified path.
+
+    ``path_type`` (DOS_PATH / NT_PATH) is accepted for API compatibility; the
+    file is always read directly through the filesystem.
+    """
+    return sdb_reader.SdbOpenDatabase(path)
 
 
-class _U(Union):
-    _fields_ = [("ullAttr", c_uint64), ("dwAttr", c_uint32), ("lpAttr", c_wchar_p)]
+def SdbCloseDatabase(db: SdbFile | None) -> None:
+    """Close the specified database (no-op; kept for API compatibility)."""
 
 
-class ATTRINFO(Structure):
-    _anonymous_ = ("_u",)
-    _fields_ = [
-        ("tAttrID", c_uint16),  # TAG
-        ("dwFlags", c_uint32),
-        ("_u", _U),  # Union for ullAttr, dwAttr, lpAttr
-    ]
-
-
-ATTRIBUTE_AVAILABLE = 0x00000001  # Attribute is available
-
-
-# BOOL WINAPI SdbFormatAttribute(
-#   _In_  PATTRINFO pAttrInfo,
-#   _Out_ LPTSTR    pchBuffer,
-#   _In_  DWORD     dwBufferSize
-# );
-APPHELP.SdbFormatAttribute.argtypes = [POINTER(ATTRINFO), c_wchar_p, c_uint32]
-APPHELP.SdbFormatAttribute.restype = c_uint32
-
-# BOOL WINAPI SdbGetFileAttributes(
-#   _In_  LPCTSTR   lpwszFileName,
-#   _Out_ PATTRINFO *ppAttrInfo,
-#   _Out_ LPDWORD   lpdwAttrCount
-# );
-APPHELP.SdbGetFileAttributes.argtypes = [
-    c_wchar_p,
-    POINTER(POINTER(ATTRINFO)),
-    POINTER(c_uint32),
-]
-APPHELP.SdbGetFileAttributes.restype = c_uint32
-
-# BOOL WINAPI SdbFreeFileAttributes(
-#   _In_ PATTRINFO pFileAttributes
-# );
-APPHELP.SdbFreeFileAttributes.argtypes = [c_void_p]
-APPHELP.SdbFreeFileAttributes.restype = c_uint32
-
-
-# BOOL WINAPI SdbGetMatchingExe(
-#   _In_opt_ HSDB            hSDB,
-#   _In_     LPCTSTR         szPath,
-#   _In_opt_ LPCTSTR         szModuleName,
-#   _In_opt_ LPCTSTR         pszEnvironment,
-#   _In_     DWORD           dwFlags,
-#   _Out_    PSDBQUERYRESULT pQueryResult
-# );
-APPHELP.SdbGetMatchingExe.argtypes = [
-    c_void_p,
-    c_wchar_p,
-    c_wchar_p,
-    c_wchar_p,
-    c_uint32,
-    POINTER(c_void_p),
-]
-APPHELP.SdbGetMatchingExe.restype = c_uint32
-
-# void WINAPI SdbReleaseMatchingExe(
-#   _In_ HSDB   hSDB,
-#   _In_ TAGREF trExe
-# );
-APPHELP.SdbReleaseMatchingExe.argtypes = [c_void_p, c_uint32]
-APPHELP.SdbReleaseMatchingExe.restype = None
-
-
-DB_INFO_FLAGS_VALID_GUID = 1
-
-
-class SDBDATABASEINFO(Structure):
-    _fields_ = [
-        ("dwFlags", c_uint32),  # DB_INFO_FLAGS_VALID_GUID
-        ("dwMajor", c_uint32),
-        ("dwMinor", c_uint32),
-        ("Description", c_wchar_p),
-        ("Id", c_uint8 * 16),  # GUID is 16 bytes
-        ("dwRuntimePlatform", c_uint32),
-    ]
-
-
-# BOOL WINAPI SdbGetDatabaseInformationByName(
-#   _In_  LPCTSTR   lpwszFileName,
-#   _Out_ PSDBDATABASEINFO *ppAttrInfo,
-# );
-APPHELP.SdbGetDatabaseInformationByName.argtypes = [
-    c_wchar_p,
-    POINTER(POINTER(SDBDATABASEINFO)),
-]
-APPHELP.SdbGetDatabaseInformationByName.restype = c_uint32
-
-# BOOL WINAPI SdbFreeDatabaseInformation(
-#   _In_ PSDBDATABASEINFO pFileAttributes
-# );
-APPHELP.SdbFreeDatabaseInformation.argtypes = [c_void_p]
-APPHELP.SdbFreeDatabaseInformation.restype = c_uint32
-
-
-def SdbOpenDatabase(path: str, path_type: int) -> c_void_p:
-    """Open a database at the specified path."""
-    return APPHELP.SdbOpenDatabase(path, path_type)
-
-
-def SdbCloseDatabase(db: c_void_p):
-    """Close the specified database."""
-    APPHELP.SdbCloseDatabase(db)
-
-
-def SdbGetFirstChild(db: c_void_p, parent: int) -> int:
+def SdbGetFirstChild(db: SdbFile, parent: int) -> int:
     """Get the first child tag of the specified parent."""
-    return APPHELP.SdbGetFirstChild(db, parent)
+    return sdb_reader.SdbGetFirstChild(db, parent)
 
 
-def SdbGetNextChild(db: c_void_p, parent: int, prev_child: int) -> int:
+def SdbGetNextChild(db: SdbFile, parent: int, prev_child: int) -> int:
     """Get the next child tag of the specified parent."""
-    return APPHELP.SdbGetNextChild(db, parent, prev_child)
+    return sdb_reader.SdbGetNextChild(db, parent, prev_child)
 
 
-def SdbGetTagFromTagID(db: c_void_p, tag_id: int) -> int:
+def SdbGetTagFromTagID(db: SdbFile, tag_id: int) -> int:
     """Get the tag from the specified tag ID."""
-    return APPHELP.SdbGetTagFromTagID(db, tag_id)
+    return sdb_reader.SdbGetTagFromTagID(db, tag_id)
 
 
-def SdbReadBYTETag(db: c_void_p, tag_id: int, default: int = 0) -> int:
+def SdbReadBYTETag(db: SdbFile, tag_id: int, default: int = 0) -> int:
     """Read a BYTE tag from the database."""
-    return APPHELP.SdbReadBYTETag(db, tag_id, default)
+    return sdb_reader.SdbReadBYTETag(db, tag_id, default)
 
 
-def SdbReadWORDTag(db: c_void_p, tag_id: int, default: int = 0) -> int:
+def SdbReadWORDTag(db: SdbFile, tag_id: int, default: int = 0) -> int:
     """Read a WORD tag from the database."""
-    return APPHELP.SdbReadWORDTag(db, tag_id, default)
+    return sdb_reader.SdbReadWORDTag(db, tag_id, default)
 
 
-def SdbReadDWORDTag(db: c_void_p, tag_id: int, default: int = 0) -> int:
+def SdbReadDWORDTag(db: SdbFile, tag_id: int, default: int = 0) -> int:
     """Read a DWORD tag from the database."""
-    return APPHELP.SdbReadDWORDTag(db, tag_id, default)
+    return sdb_reader.SdbReadDWORDTag(db, tag_id, default)
 
 
-def SdbReadQWORDTag(db: c_void_p, tag_id: int, default: int = 0) -> int:
+def SdbReadQWORDTag(db: SdbFile, tag_id: int, default: int = 0) -> int:
     """Read a QWORD tag from the database."""
-    return APPHELP.SdbReadQWORDTag(db, tag_id, default)
+    return sdb_reader.SdbReadQWORDTag(db, tag_id, default)
 
 
-def SdbReadBinaryTag(db: c_void_p, tag_id: int) -> bytes:
+def SdbReadBinaryTag(db: SdbFile, tag_id: int) -> bytes:
     """Read a binary tag from the database."""
-    size = APPHELP.SdbGetTagDataSize(db, tag_id)
-    if size == 0:
-        return b""
-    data = (c_ubyte * size)()
-    result = APPHELP.SdbReadBinaryTag(db, tag_id, data, size)
-    if result == 0:
-        raise ValueError(f"Failed to read binary tag 0x{tag_id:x}")
-    return bytes(data)
+    return sdb_reader.SdbReadBinaryTag(db, tag_id)
 
 
-def SdbGetStringTagPtr(db: c_void_p, tag_id: int) -> str:
-    """Get the string pointer of the specified tag."""
-    return APPHELP.SdbGetStringTagPtr(db, tag_id)
-
-
-def GetFileAttributes(file_name: str):
-    """Get file attributes for the specified file."""
-    attr_info = POINTER(ATTRINFO)()
-    attr_count = c_uint32()
-    result = APPHELP.SdbGetFileAttributes(
-        file_name, byref(attr_info), byref(attr_count)
-    )
-    if result == 0:
-        raise ValueError(f"Failed to get file attributes for '{file_name}'")
-    return attr_info, attr_count
-
-
-def SdbFormatAttribute(attr_info: ATTRINFO) -> str:
-    """Format the attribute information into a string."""
-    buffer_size = 1024 * 2
-    buffer = create_unicode_buffer(buffer_size)
-    result = APPHELP.SdbFormatAttribute(pointer(attr_info), buffer, buffer_size)
-    if result == 0:
-        name = tag_id_to_string(attr_info.tAttrID)
-        raise ValueError(f"Failed to format attribute ({name})")
-    return buffer.value if buffer.value else ""
-
-
-def SdbFreeFileAttributes(attr_info):
-    """Free the file attributes structure."""
-    APPHELP.SdbFreeFileAttributes(attr_info)
-
-
-def GetDatabaseInformationByName(file_name: str):
-    """Get database information for the specified file."""
-    db_info = POINTER(SDBDATABASEINFO)()
-    result = APPHELP.SdbGetDatabaseInformationByName(file_name, byref(db_info))
-    if result == 0:
-        raise ValueError(f"Failed to get database information for '{file_name}'")
-    return db_info
-
-
-def SdbFreeDatabaseInformation(db_info):
-    """Free the database information structure."""
-    APPHELP.SdbFreeDatabaseInformation(db_info)
+def SdbGetStringTagPtr(db: SdbFile, tag_id: int) -> str:
+    """Get the string value of the specified tag."""
+    value = sdb_reader.SdbGetStringTagPtr(db, tag_id)
+    return value if value is not None else ""

--- a/sdbtool/attributes.py
+++ b/sdbtool/attributes.py
@@ -1,25 +1,25 @@
 """
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
-PURPOSE:     Wrapper around the low level apphelp file attributes API
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+PURPOSE:     Wrapper around the file attributes API
+COPYRIGHT:   Copyright 2025,2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 import os
-from sdbtool.apphelp.winapi import (
-    GetFileAttributes,
-    SdbFormatAttribute,
-    SdbFreeFileAttributes,
+from sdbtool.apphelp.fileattr import (
+    get_file_attributes,
+    format_attribute,
     ATTRIBUTE_AVAILABLE,
 )
 
 
 def get_attributes(file_name: str | os.PathLike) -> list[str]:
-    attr_info, attr_count = GetFileAttributes(os.fspath(file_name))
-    res = [
-        SdbFormatAttribute(attr_info[i])
-        for i in range(attr_count.value)
-        if attr_info[i].dwFlags & ATTRIBUTE_AVAILABLE != 0
+    try:
+        attrs = get_file_attributes(file_name)
+    except OSError as e:
+        raise ValueError(f"Failed to get file attributes for '{file_name}'") from e
+    return [
+        format_attribute(attr)
+        for attr in attrs
+        if attr.flags & ATTRIBUTE_AVAILABLE != 0
     ]
-    SdbFreeFileAttributes(attr_info)
-    return res

--- a/sdbtool/info.py
+++ b/sdbtool/info.py
@@ -1,18 +1,22 @@
 """
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
-PURPOSE:     Wrapper around the low level apphelp database information API
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+PURPOSE:     Read high-level information about an SDB file.
+COPYRIGHT:   Copyright 2025,2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 import os
 from dataclasses import dataclass
 from uuid import UUID
-from sdbtool.apphelp.winapi import (
-    GetDatabaseInformationByName,
-    SdbFreeDatabaseInformation,
-    DB_INFO_FLAGS_VALID_GUID,
-)
+from sdbtool.apphelp import sdb_reader
+
+DB_INFO_FLAGS_VALID_GUID = 1
+# Always set by the (Win10+) SdbGetDatabaseInformationByName implementation.
+_DB_INFO_FLAGS_BASE = 0x10000000
+
+_TAG_DATABASE = 0x7001
+_TAG_RUNTIME_PLATFORM = 0x4021
+_PLATFORM_MASK = 0x1F  # X86 | AMD64 | X86_ON_AMD64 | ARM | ARM64
 
 
 @dataclass
@@ -27,19 +31,40 @@ class DatabaseInformation:
     dwRuntimePlatform: int | None
 
 
+def _runtime_platform(pdb: sdb_reader.SdbFile) -> int:
+    """Reproduce the dwRuntimePlatform value reported by apphelp.dll.
+
+    Windows derives this from the DATABASE's RUNTIME_PLATFORM tag, reporting the
+    most significant platform bit (e.g. 0x25 -> 4, 0x82 -> 2), and defaults to 4
+    (X86_ON_AMD64) when the tag is absent.
+    """
+    root = sdb_reader.SdbFindFirstTag(pdb, sdb_reader.TAGID_ROOT, _TAG_DATABASE)
+    bits = 0
+    if root != sdb_reader.TAGID_NULL:
+        tag = sdb_reader.SdbFindFirstTag(pdb, root, _TAG_RUNTIME_PLATFORM)
+        if tag != sdb_reader.TAGID_NULL:
+            bits = sdb_reader.SdbReadDWORDTag(pdb, tag) & _PLATFORM_MASK
+    if not bits:
+        return 4
+    return 1 << (bits.bit_length() - 1)
+
+
 def get_info(file_name: str | os.PathLike) -> DatabaseInformation:
-    db_info = GetDatabaseInformationByName(os.fspath(file_name))
+    pdb = sdb_reader.SdbOpenDatabase(os.fspath(file_name))
+    if pdb is None:
+        raise ValueError(f"Failed to get database information for '{file_name}'")
+
+    flags = _DB_INFO_FLAGS_BASE
     id_value = None
-    if db_info.contents.dwFlags & DB_INFO_FLAGS_VALID_GUID:
-        data = bytes(db_info.contents.Id)
-        id_value = UUID(bytes_le=data)
-    res = DatabaseInformation(
-        Description=db_info.contents.Description or None,
-        dwMajor=db_info.contents.dwMajor,
-        dwMinor=db_info.contents.dwMinor,
-        dwFlags=db_info.contents.dwFlags,
+    if pdb.database_id is not None:
+        flags |= DB_INFO_FLAGS_VALID_GUID
+        id_value = UUID(bytes_le=pdb.database_id)
+
+    return DatabaseInformation(
+        Description=pdb.database_name or None,
+        dwMajor=pdb.major,
+        dwMinor=pdb.minor,
+        dwFlags=flags,
         Id=id_value,
-        dwRuntimePlatform=db_info.contents.dwRuntimePlatform or None,
+        dwRuntimePlatform=_runtime_platform(pdb),
     )
-    SdbFreeDatabaseInformation(db_info)
-    return res

--- a/tests/test_apphelp_winapi.py
+++ b/tests/test_apphelp_winapi.py
@@ -1,35 +1,31 @@
 """
 PROJECT:     sdbtool
 LICENSE:     MIT (https://spdx.org/licenses/MIT)
-PURPOSE:     tests for the apphelp.winapi module.
-COPYRIGHT:   Copyright 2025 Mark Jansen <mark.jansen@reactos.org>
+PURPOSE:     tests for the pure-Python apphelp reader / file-attribute layer.
+COPYRIGHT:   Copyright 2025,2026 Mark Jansen <mark.jansen@reactos.org>
 """
 
 import pytest
-from ctypes import c_void_p
-from sdbtool.apphelp.winapi import (
-    APPHELP,
-    ATTRINFO,
-    SdbFormatAttribute,
-    SdbReadBinaryTag,
-)
+from sdbtool.apphelp import sdb_reader
+from sdbtool.apphelp.fileattr import AttrInfo, format_attribute, ATTRIBUTE_FAILED
 
 
-def test_SdbReadBinaryTag_fails(monkeypatch):
-    monkeypatch.setattr(APPHELP, "SdbGetTagDataSize", lambda pdb, tagid: 1)
-    monkeypatch.setattr(APPHELP, "SdbReadBinaryTag", lambda pdb, tagid, buffer, size: 0)
+def test_SdbReadBinaryTag_not_binary():
+    # A zero-length buffer has no valid tags, so reading a binary tag must fail.
+    pdb = sdb_reader.SdbFile(b"", 2, 0)
+    with pytest.raises(ValueError, match="is not a binary tag"):
+        sdb_reader.SdbReadBinaryTag(pdb, 0x1234)
 
-    # Check that the function raises an error when trying to read a binary tag that should succeed, but doesn't
+
+def test_SdbReadBinaryTag_truncated(monkeypatch):
+    pdb = sdb_reader.SdbFile(b"", 2, 0)
+    # Pretend there is a binary tag, but the data cannot be read.
+    monkeypatch.setattr(sdb_reader, "_check_type", lambda *a: True)
     with pytest.raises(ValueError, match="Failed to read binary tag"):
-        SdbReadBinaryTag(c_void_p(), 0x1234)
+        sdb_reader.SdbReadBinaryTag(pdb, 0x1234)
 
 
-def test_SdbFormatAttribute_fails(monkeypatch):
-    monkeypatch.setattr(APPHELP, "SdbFormatAttribute", lambda attr, buf, size: 0)
-
-    attr = ATTRINFO()
-    attr.tAttrID = 0x7001  # TAG_DATABASE
-
-    # Check that the function raises an error when trying to format an attribute that should succeed, but fails
+def test_format_attribute_fails():
+    attr = AttrInfo(0x7001, ATTRIBUTE_FAILED, None)  # TAG_DATABASE
     with pytest.raises(ValueError, match="Failed to format attribute \\(DATABASE\\)"):
-        SdbFormatAttribute(attr)
+        format_attribute(attr)

--- a/tests/test_fileattr.py
+++ b/tests/test_fileattr.py
@@ -1,0 +1,150 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     tests for the pure-Python file-attribute layer edge cases.
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+import struct
+from types import SimpleNamespace
+
+from sdbtool.apphelp import fileattr as fa
+from sdbtool.apphelp.fileattr import (
+    AttrInfo,
+    ATTRIBUTE_AVAILABLE,
+    format_attribute,
+    get_file_attributes,
+)
+
+
+def _attr(attrs, tag):
+    return next(a for a in attrs if a.tag == tag)
+
+
+def test_module_type():
+    assert fa._module_type(b"") == fa._MODTYPE_NONE
+    assert fa._module_type(b"MZ") == fa._MODTYPE_DOS  # too short for a header
+    dos = bytearray(0x40)
+    dos[0:2] = b"MZ"
+    struct.pack_into("<I", dos, 0x3C, 0x10000)  # e_lfanew past the end
+    assert fa._module_type(bytes(dos)) == fa._MODTYPE_DOS
+    ne = bytearray(0x60)
+    ne[0:2] = b"MZ"
+    struct.pack_into("<I", ne, 0x3C, 0x40)
+    ne[0x40:0x42] = b"NE"
+    assert fa._module_type(bytes(ne)) == fa._MODTYPE_NE
+    junk = bytearray(0x60)
+    junk[0:2] = b"MZ"
+    struct.pack_into("<I", junk, 0x3C, 0x40)
+    junk[0x40:0x44] = b"ZZZZ"
+    assert fa._module_type(bytes(junk)) == fa._MODTYPE_DOS
+
+
+def test_calculate_file_checksum():
+    assert fa._calculate_file_checksum(b"") == 0  # size < 4
+    assert fa._calculate_file_checksum(b"\x00" * 0x1000) == 0  # last-0x1000 branch
+    assert fa._calculate_file_checksum(b"\x00" * 0x1200) == 0  # offset-0x200 branch
+
+
+def test_crc_checksum():
+    assert fa._crc_checksum(b"") == 0
+    # > 0x2000 exercises the head+tail sampling branch
+    assert isinstance(fa._crc_checksum(b"\x01" * 0x2001), int)
+
+
+def test_decode_passthrough():
+    assert fa._decode("already-str") == "already-str"
+    assert fa._decode(b"bytes") == "bytes"
+
+
+def test_export_name_helper():
+    assert fa._export_name(SimpleNamespace()) is None  # no export dir
+    pe = SimpleNamespace(
+        DIRECTORY_ENTRY_EXPORT=SimpleNamespace(struct=SimpleNamespace(Name=0))
+    )
+    assert fa._export_name(pe) is None  # name rva 0
+    pe = SimpleNamespace(
+        DIRECTORY_ENTRY_EXPORT=SimpleNamespace(struct=SimpleNamespace(Name=0x10)),
+        get_string_at_rva=lambda rva: b"",
+    )
+    assert fa._export_name(pe) is None  # empty name
+    pe = SimpleNamespace(
+        DIRECTORY_ENTRY_EXPORT=SimpleNamespace(struct=SimpleNamespace(Name=0x10)),
+        get_string_at_rva=lambda rva: b"mylib.dll",
+    )
+    assert fa._export_name(pe) == "mylib.dll"
+
+
+def test_version_resource_helper():
+    ff = object()
+    var_no_trans = SimpleNamespace(Key=b"VarFileInfo", Var=[SimpleNamespace(entry={})])
+    var = SimpleNamespace(
+        Key=b"VarFileInfo",
+        Var=[
+            SimpleNamespace(entry={b"Translation": "0x0409 0x04b0"}),
+            SimpleNamespace(entry={b"Translation": "0x0413 0x04b0"}),
+        ],
+    )
+    strings = SimpleNamespace(
+        Key=b"StringFileInfo",
+        StringTable=[SimpleNamespace(entries={b"CompanyName": b"ACME"})],
+    )
+    pe = SimpleNamespace(VS_FIXEDFILEINFO=[ff], FileInfo=[[var_no_trans, var, strings]])
+    fixed, sd, lang = fa._version_resource(pe)
+    assert fixed is ff
+    assert sd == {"CompanyName": "ACME"}
+    assert lang == 0x0409  # first translation wins
+
+    empty = SimpleNamespace(VS_FIXEDFILEINFO=[], FileInfo=None)
+    assert fa._version_resource(empty) == (None, {}, None)
+
+
+def test_format_value_branches():
+    def fmt(tag, value):
+        return format_attribute(AttrInfo(tag, ATTRIBUTE_AVAILABLE, value))
+
+    assert fmt(fa.TAG_SIZE, 2048) == 'SIZE="2048"'
+    assert fmt(fa.TAG_BIN_FILE_VERSION, 0x0001000200030004) == 'BIN_FILE_VERSION="1.2.3.4"'
+    assert fmt(fa.TAG_LINK_DATE, 0) == 'LINK_DATE="01/01/1970 00:00:00"'
+    assert fmt(fa.TAG_VER_LANGUAGE, 0xFFFF) == 'VER_LANGUAGE="Language Neutral [0xffff]"'
+    assert fmt(fa.TAG_VER_LANGUAGE, 0x0409) == 'VER_LANGUAGE="English (United States) [0x409]"'
+    assert fmt(fa.TAG_VER_LANGUAGE, 0x0999) == 'VER_LANGUAGE="Language Neutral [0x999]"'
+    assert fmt(fa.TAG_MODULE_TYPE, 3) == 'MODULE_TYPE="WIN32"'
+    assert fmt(fa.TAG_MODULE_TYPE, 99) == 'MODULE_TYPE="NONE"'
+    assert fmt(fa.TAG_PRODUCT_NAME, "Name") == 'PRODUCT_NAME="Name"'
+    assert fmt(fa.TAG_CHECKSUM, 0xABCD) == 'CHECKSUM="0xABCD"'
+
+
+def test_get_file_attributes_empty(tmp_path):
+    f = tmp_path / "empty.bin"
+    f.write_bytes(b"")
+    attrs = get_file_attributes(f)
+    assert _attr(attrs, fa.TAG_SIZE).value == 0
+    assert not (_attr(attrs, fa.TAG_CHECKSUM).flags & ATTRIBUTE_AVAILABLE)
+    assert _attr(attrs, fa.TAG_CRC_CHECKSUM).value == 0
+    assert not (_attr(attrs, fa.TAG_MODULE_TYPE).flags & ATTRIBUTE_AVAILABLE)
+    assert not (_attr(attrs, fa.TAG_VER_LANGUAGE).flags & ATTRIBUTE_AVAILABLE)
+
+
+def test_get_file_attributes_dos(tmp_path):
+    data = bytearray(0x100)
+    data[0:2] = b"MZ"
+    f = tmp_path / "stub.exe"
+    f.write_bytes(bytes(data))
+    attrs = get_file_attributes(f)
+    mt = _attr(attrs, fa.TAG_MODULE_TYPE)
+    assert mt.flags & ATTRIBUTE_AVAILABLE and mt.value == fa._MODTYPE_DOS
+    assert _attr(attrs, fa.TAG_CHECKSUM).flags & ATTRIBUTE_AVAILABLE
+
+
+def test_get_file_attributes_bad_pe(tmp_path):
+    # Looks like a PE (MZ + PE signature) but is not parseable -> pefile fails.
+    data = bytearray(0x44)
+    data[0:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, 0x40)
+    data[0x40:0x44] = b"PE\x00\x00"
+    f = tmp_path / "broken.exe"
+    f.write_bytes(bytes(data))
+    attrs = get_file_attributes(f)
+    assert not (_attr(attrs, fa.TAG_SIZE_OF_IMAGE).flags & ATTRIBUTE_AVAILABLE)
+    assert not (_attr(attrs, fa.TAG_PE_CHECKSUM).flags & ATTRIBUTE_AVAILABLE)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -30,3 +30,16 @@ def test_info():
 
     with pytest.raises(ValueError, match="Failed to get database information for"):
         get_info(TESTDATA_FOLDER / "nonexistent.sdb")
+
+
+def test_info_header_only(tmp_path):
+    # A header-only database has no DATABASE tag: runtime platform defaults to 4.
+    import struct
+
+    f = tmp_path / "header_only.sdb"
+    f.write_bytes(struct.pack("<I", 2) + struct.pack("<I", 0) + b"sdbf")
+    db_info = get_info(f)
+    assert db_info.Description is None
+    assert db_info.Id is None
+    assert db_info.dwFlags == 0x10000000
+    assert db_info.dwRuntimePlatform == 4

--- a/tests/test_sdb_reader.py
+++ b/tests/test_sdb_reader.py
@@ -1,0 +1,192 @@
+"""
+PROJECT:     sdbtool
+LICENSE:     MIT (https://spdx.org/licenses/MIT)
+PURPOSE:     tests for the pure-Python SDB reader edge cases.
+COPYRIGHT:   Copyright 2026 Mark Jansen <mark.jansen@reactos.org>
+"""
+
+import struct
+import pytest
+from sdbtool.apphelp import sdb_reader as r
+from sdbtool.apphelp.sdb_reader import SdbFile
+
+
+def W(v: int) -> bytes:
+    return struct.pack("<H", v)
+
+
+def D(v: int) -> bytes:
+    return struct.pack("<I", v)
+
+
+def mk(data: bytes, stringtable: int = 0) -> SdbFile:
+    pdb = SdbFile(data, 2, 0)
+    pdb.stringtable = stringtable
+    return pdb
+
+
+def test_read_data_bounds():
+    pdb = mk(b"abcd")
+    assert r.SdbpReadData(pdb, 0, 0) is None  # nothing to read / overflow guard
+    assert r.SdbpReadData(pdb, 0, 10) is None  # out of bounds
+    assert r.SdbpReadData(pdb, 0, 2) == b"ab"
+
+
+def test_get_tag_out_of_bounds():
+    assert r.SdbGetTagFromTagID(mk(b""), 0) == r.TAG_NULL
+
+
+def test_get_tag_data_size():
+    assert r.SdbGetTagDataSize(mk(W(0x0000)), 0) == 0  # NULL nibble
+    assert r.SdbGetTagDataSize(mk(W(0x4000)), 0) == 4  # fixed DWORD
+    assert r.SdbGetTagDataSize(mk(W(0x7000) + D(5)), 0) == 5  # dynamic list
+    assert r.SdbGetTagDataSize(mk(W(0x7000)), 0) == 0  # truncated size
+
+
+def test_tag_size_padding():
+    assert r._sdbp_get_tag_size(mk(W(0x0000)), 0) == 0  # NULL nibble
+    assert r._sdbp_get_tag_size(mk(W(0x2000) + b"\x01"), 0) == 4  # BYTE -> pad to 2
+    assert r._sdbp_get_tag_size(mk(W(0x7000) + D(4) + b"....", 0), 0) == 10
+
+
+# Tags never live at offset 0 in a real database (that is the 12-byte header /
+# TAGID_ROOT), so crafted buffers prepend a header so tag ids are non-zero.
+HDR = b"\x00" * 12
+
+
+def test_first_child():
+    assert r.SdbGetFirstChild(mk(b"x" * 12), r.TAGID_ROOT) == r.TAGID_NULL
+    assert r.SdbGetFirstChild(mk(b"x" * 16), r.TAGID_ROOT) == r._TAGID_ROOT
+    assert r.SdbGetFirstChild(mk(HDR + W(0x4000) + D(0)), 12) == r.TAGID_NULL  # not list
+    assert r.SdbGetFirstChild(mk(HDR + W(0x7000) + D(0)), 12) == r.TAGID_NULL  # empty
+    pdb = mk(HDR + W(0x7000) + D(4) + W(0x4000) + D(0))
+    assert r.SdbGetFirstChild(pdb, 12) == 18  # 12 + sizeof(TAG) + sizeof(DWORD)
+
+
+def test_next_child():
+    # prev_child is a NULL-nibble tag -> size 0 -> no next
+    assert r.SdbGetNextChild(mk(HDR + W(0x0000) + b"\x00" * 8), r.TAGID_ROOT, 12) == r.TAGID_NULL
+    # next_child runs past the end of the database
+    pdb = mk(HDR + W(0x4000) + D(0))  # one DWORD tag at 12
+    assert r.SdbGetNextChild(pdb, r.TAGID_ROOT, 12) == r.TAGID_NULL
+    # ROOT parent: returns the next tag
+    pdb = mk(HDR + W(0x4000) + D(0) + W(0x4000) + D(0))
+    assert r.SdbGetNextChild(pdb, r.TAGID_ROOT, 12) == 18
+    # parent has zero size (points at a NULL-nibble tag) -> no next
+    pdb = mk(HDR + W(0x4000) + D(0) + W(0x4000) + D(0) + W(0x0000))
+    assert r.SdbGetNextChild(pdb, 24, 12) == r.TAGID_NULL
+    # next_child is outside the parent's range (list size only covers first child)
+    pdb = mk(HDR + W(0x7000) + D(6) + W(0x4000) + D(0) + W(0x4000) + D(0))
+    assert r.SdbGetNextChild(pdb, 12, 18) == r.TAGID_NULL
+
+
+def test_find_first_tag():
+    pdb = mk(W(0x7000) + D(12) + W(0x4001) + D(0) + W(0x4002) + D(0))
+    assert r.SdbFindFirstTag(pdb, 0, 0x4002) == 12
+    assert r.SdbFindFirstTag(pdb, 0, 0x9999) == r.TAGID_NULL
+
+
+def test_read_scalar_wrong_type_returns_default():
+    pdb = mk(W(0x4000) + D(7))  # a DWORD tag
+    assert r.SdbReadDWORDTag(pdb, 0) == 7
+    assert r.SdbReadBYTETag(pdb, 0, default=9) == 9
+    assert r.SdbReadWORDTag(pdb, 0, default=9) == 9
+    assert r.SdbReadQWORDTag(pdb, 0, default=9) == 9
+    # correct types
+    assert r.SdbReadBYTETag(mk(W(0x2000) + b"\xab"), 0) == 0xAB
+    assert r.SdbReadWORDTag(mk(W(0x3000) + W(0xABCD)), 0) == 0xABCD
+    assert r.SdbReadQWORDTag(mk(W(0x5000) + struct.pack("<Q", 5)), 0) == 5
+    # correct type but truncated value falls back to default
+    assert r.SdbReadBYTETag(mk(W(0x2000)), 0, default=3) == 3
+    assert r.SdbReadWORDTag(mk(W(0x3000)), 0, default=3) == 3
+    assert r.SdbReadDWORDTag(mk(W(0x4000)), 0, default=3) == 3
+    assert r.SdbReadQWORDTag(mk(W(0x5000)), 0, default=3) == 3
+    # wrong type for DWORD falls back to default
+    assert r.SdbReadDWORDTag(mk(W(0x2000) + b"\x00"), 0, default=3) == 3
+
+
+def test_read_binary_tag():
+    assert r.SdbReadBinaryTag(mk(W(0x9000) + D(0)), 0) == b""
+    assert r.SdbReadBinaryTag(mk(W(0x9000) + D(2) + b"hi"), 0) == b"hi"
+    with pytest.raises(ValueError, match="is not a binary tag"):
+        r.SdbReadBinaryTag(mk(W(0x4000) + D(0)), 0)
+    with pytest.raises(ValueError, match="Failed to read binary tag"):
+        r.SdbReadBinaryTag(mk(W(0x9000)), 0)  # missing size
+    with pytest.raises(ValueError, match="Failed to read binary tag"):
+        r.SdbReadBinaryTag(mk(W(0x9000) + D(10) + b"hi"), 0)  # truncated data
+
+
+def _string_tag(text: str) -> bytes:
+    raw = text.encode("utf-16-le") + b"\x00\x00"
+    return W(0x8000) + D(len(raw)) + raw
+
+
+def test_string_tag_ptr():
+    assert r.SdbGetStringTagPtr(mk(b""), 0) is None  # TAG_NULL
+    # STRING type, inline
+    assert r.SdbGetStringTagPtr(mk(_string_tag("hello")), 0) == "hello"
+    # non-string type
+    assert r.SdbGetStringTagPtr(mk(W(0x4000) + D(0)), 0) is None
+    # STRINGREF without a string table
+    assert r.SdbGetStringTagPtr(mk(W(0x6000) + D(0), stringtable=0), 0) is None
+    # STRINGREF with a table but truncated offset
+    assert r.SdbGetStringTagPtr(mk(W(0x6000), stringtable=4), 0) is None
+    # STRING with missing size dword
+    assert r.SdbGetStringTagPtr(mk(W(0x8000)), 0) is None
+    # STRING whose declared data is missing
+    assert r.SdbGetStringTagPtr(mk(W(0x8000) + D(100)), 0) is None
+    # STRING with malformed (odd-length) UTF-16 data
+    assert r.SdbGetStringTagPtr(mk(W(0x8000) + D(1) + b"\x00"), 0) is None
+
+
+def test_stringref_resolution():
+    # Build: [STRING-table list][stringref]. Lay out so the stringref resolves.
+    # stringtable list at offset 0: TAG(0x7801) + size; item is a STRING entry.
+    payload = "AB".encode("utf-16-le") + b"\x00\x00"
+    item = W(0x8801) + D(len(payload)) + payload  # string-table entry
+    table = W(0x7801) + D(len(item)) + item  # table header (6 bytes) + item
+    item_off = 6  # offset of the item relative to the table start
+    # The stringref stores the offset of the item relative to the table start.
+    sref = W(0x6001) + D(item_off)
+    data = HDR + table + sref
+    pdb = mk(data, stringtable=12)  # table starts right after the 12-byte header
+    sref_tagid = 12 + len(table)
+    assert r.SdbGetStringTagPtr(pdb, sref_tagid) == "AB"
+
+
+def test_resolve_metadata_non16_id_and_unresolved_name():
+    # DATABASE { DATABASE_ID (4 bytes), NAME (stringref, no string table) }
+    id_child = W(0x9007) + D(4) + b"ABCD"
+    name_child = W(0x6001) + D(0)
+    children = id_child + name_child
+    database = W(0x7001) + D(len(children)) + children
+    pdb = mk(HDR + database)
+    r._resolve_metadata(pdb)
+    assert pdb.database_id is None  # 4 bytes != 16 -> not a GUID
+    assert pdb.database_name is None  # stringref with no string table
+
+
+def test_resolve_metadata_truncated_id():
+    # DATABASE_ID claims 16 bytes but the data is truncated -> read raises -> ignored.
+    id_child = W(0x9007) + D(16) + b"AB"
+    database = W(0x7001) + D(len(id_child)) + id_child
+    pdb = mk(HDR + database)
+    r._resolve_metadata(pdb)
+    assert pdb.database_id is None
+
+
+def test_open_database(tmp_path):
+    assert r.SdbOpenDatabase(str(tmp_path / "missing.sdb")) is None  # OSError
+    bad = tmp_path / "bad.sdb"
+    bad.write_bytes(b"short")
+    assert r.SdbOpenDatabase(str(bad)) is None  # too short / bad magic
+    badmagic = tmp_path / "bm.sdb"
+    badmagic.write_bytes(D(2) + D(0) + b"XXXX")
+    assert r.SdbOpenDatabase(str(badmagic)) is None  # wrong magic
+    badver = tmp_path / "bv.sdb"
+    badver.write_bytes(D(9) + D(0) + b"sdbf")
+    assert r.SdbOpenDatabase(str(badver)) is None  # unsupported major
+    ok = tmp_path / "ok.sdb"
+    ok.write_bytes(D(2) + D(1) + b"sdbf")
+    pdb = r.SdbOpenDatabase(str(ok))
+    assert pdb is not None and pdb.major == 2 and pdb.minor == 1

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -178,6 +187,7 @@ version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "pefile" },
 ]
 
 [package.dev-dependencies]
@@ -187,7 +197,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "click", specifier = ">=8.2.1" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.2.1" },
+    { name = "pefile", specifier = ">=2024.8.26" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Replaces the runtime dependency on the native **`apphelp.dll`** with a pure-Python implementation. The tool now reads/parses SDB files and computes PE file attributes without any native library, making it **cross-platform** and self-contained.

## What changed

- **`apphelp/sdb_reader.py`** (new) — pure-Python SDB tag reader, ported from ReactOS `sdbread.c` / `sdbapi.c`. Includes the WORD-aligned tag-data padding and empty-list handling needed to match `apphelp.dll` byte-for-byte.
- **`apphelp/fileattr.py`** (new) — `SdbGetFileAttributes` / `SdbFormatAttribute` reimplemented using **`pefile`** for PE-header and version-resource parsing. Reproduces the Windows `apphelp.dll` attribute set and formatting exactly, including the Windows-only `FILESIZE`, `SIZE_OF_IMAGE` and `CRC_CHECKSUM`.
  - `CRC_CHECKSUM` was reverse-engineered: it is a zlib CRC-32 over a head+tail sample of the file (first `min(size, 0x2000)` bytes, with the upper half replaced by the last `0x1000` bytes when the file is larger than `0x2000`).
- **`apphelp/winapi.py`** — reduced to a thin pure-Python facade (no `ctypes` / `windll`).
- **`info.py`** — database information read directly from the SDB.
- **`attributes.py`** — uses the new pure-Python attribute layer.
- **`pyproject.toml`** — adds the `pefile` dependency and drops the Windows-only OS classifier.

## Known limitation

`VER_LANGUAGE` reproduces the `"<name> [0xNNNN]"` format exactly for language-neutral files (the common case for shim databases) and a small set of common locales; other language **names** fall back to "Language Neutral". The `[0xNNNN]` value is always exact.

## Verification

- All **34 tests pass**.
- Output verified **byte-for-byte against the native `apphelp.dll`** for `sdb2xml`, `sdb2json`, `info` and `attributes` across all test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)